### PR TITLE
Custom encoding support

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -27,7 +27,8 @@ public final class Connection {
         database: String,
         port: UInt32,
         socket: String?,
-        flag: UInt
+        flag: UInt,
+        encoding: String
     ) throws {
         mysql_thread_init()
         cConnection = mysql_init(nil)
@@ -35,6 +36,8 @@ public final class Connection {
         guard mysql_real_connect(cConnection, host, user, password, database, port, socket, flag) != nil else {
             throw Database.Error.connection(error)
         }
+        
+        mysql_set_character_set(cConnection, encoding)
     }
 
     deinit {

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -60,7 +60,8 @@ public final class Database {
         database: String,
         port: UInt = 3306,
         socket: String? = nil,
-        flag: UInt = 0
+        flag: UInt = 0,
+        encoding: String = "utf8"
     ) throws {
         try Database.activeLock.locked {
             /// Initializes the server that will
@@ -77,6 +78,7 @@ public final class Database {
         self.port = UInt32(port)
         self.socket = socket
         self.flag = flag
+        self.encoding = encoding
     }
 
     private let host: String
@@ -86,6 +88,7 @@ public final class Database {
     private let port: UInt32
     private let socket: String?
     private let flag: UInt
+    private let encoding: String
 
     static private var activeLock = Lock()
 
@@ -222,7 +225,8 @@ public final class Database {
             database: database,
             port: port,
             socket: socket,
-            flag: flag
+            flag: flag,
+            encoding: encoding
         )
     }
 

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -48,6 +48,9 @@ public final class Database {
             the string specifies the socket or named pipe to use.
         - parameter flag: Usually 0, but can be set to a combination of the 
             flags at http://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html
+         - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
+            used, since "utf8" does not fully implement the UTF8 standard and does
+            not support Unicode.
 
 
         - throws: `Error.connection(String)` if the call to


### PR DESCRIPTION
Note: You will still need to manually alter tables to support this encoding. See vapor/fluent#74.