### PR TITLE
Type coersion for 32-bit platforms

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -60,7 +60,7 @@ public final class Connection {
             // Prepares the created statement
             // This parses `?` in the query and
             // prepares them to attach parameterized bindings.
-            guard mysql_stmt_prepare(statement, query, strlen(query)) == 0 else {
+            guard mysql_stmt_prepare(statement, query, UInt(strlen(query))) == 0 else {
                 throw Error.prepare(error)
             }
 


### PR DESCRIPTION
The result type of strlen changes with word size, but
mysql_stmt_prepare's third argument is fixed as an unsigned long.  This
explicitly coerces the type to match.  On 64-bit it's optimized away.