### PR TITLE
Add datetime support

### DIFF
--- a/Sources/MySQL/Bind.swift
+++ b/Sources/MySQL/Bind.swift
@@ -125,10 +125,22 @@ public final class Bind {
      Creates an input binding from an Date.
      */
     public convenience init(_ date: Date) {
-        let buffer = UnsafeMutablePointer<Date>.allocate(capacity: 1)
-        buffer.initialize(to: date)
         
-        self.init(type: MYSQL_TYPE_DATETIME, buffer: buffer, bufferLength: MemoryLayout<Date>.size)
+        var ts = MYSQL_TIME()
+        
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .second], from: date)
+        ts.year = UInt32(components.year!)
+        ts.month = UInt32(components.month!)
+        ts.day = UInt32(components.day!)
+        ts.hour = UInt32(components.hour!)
+        ts.second = UInt32(components.second!)
+        
+        
+        let buffer = UnsafeMutablePointer<MYSQL_TIME>.allocate(capacity: 1)
+        buffer.initialize(to: ts)
+            
+        self.init(type: MYSQL_TYPE_DATETIME, buffer: buffer, bufferLength: MemoryLayout<MYSQL_TIME>.size)
     }
     
     /**

--- a/Sources/MySQL/Bind.swift
+++ b/Sources/MySQL/Bind.swift
@@ -129,11 +129,12 @@ public final class Bind {
         var ts = MYSQL_TIME()
         
         let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day, .hour, .second], from: date)
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
         ts.year = UInt32(components.year!)
         ts.month = UInt32(components.month!)
         ts.day = UInt32(components.day!)
         ts.hour = UInt32(components.hour!)
+        ts.minute = UInt32(components.minute!)
         ts.second = UInt32(components.second!)
         
         

--- a/Sources/MySQL/Bind.swift
+++ b/Sources/MySQL/Bind.swift
@@ -1,5 +1,6 @@
 import Core
 import JSON
+import Foundation
 
 #if os(Linux)
 #if MARIADB
@@ -121,6 +122,16 @@ public final class Bind {
     }
     
     /**
+     Creates an input binding from an Date.
+     */
+    public convenience init(_ date: Date) {
+        let buffer = UnsafeMutablePointer<Date>.allocate(capacity: 1)
+        buffer.initialize(to: date)
+        
+        self.init(type: MYSQL_TYPE_DATETIME, buffer: buffer, bufferLength: MemoryLayout<Date>.size)
+    }
+    
+    /**
         Creates an input binding from an array of bytes.
     */
     public convenience init(_ bytes: Bytes) {
@@ -229,6 +240,8 @@ extension Node {
             return Bind(bytes)
         case .bool(let bool):
             return Bind(bool ? 1 : 0)
+        case .date(let date):
+            return Bind(date)
         }
     }
 }


### PR DESCRIPTION
I am submitting a series of pull requests to add Date as a class in Node and datetime and timestamp support in Fluent. This allows for full support for time throughout Vapor.

Specifically, there are pull requests for Vapor, Fluent, Node, JSON, MySQL, Leaf, and FluentMySQL