### PR TITLE
Vapor to respect option files like my.cnf

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -33,7 +33,7 @@ public final class Connection {
         socket: String?,
         flag: UInt,
         encoding: String,
-        optionsGroupName: String="vapor"
+        optionsGroupName: String = "vapor"
     ) throws {
         mysql_thread_init()
         cConnection = mysql_init(nil)

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -32,10 +32,13 @@ public final class Connection {
         port: UInt32,
         socket: String?,
         flag: UInt,
-        encoding: String
+        encoding: String,
+        optionsGroupName: String="vapor"
     ) throws {
         mysql_thread_init()
         cConnection = mysql_init(nil)
+
+        mysql_options(cConnection, MYSQL_READ_DEFAULT_GROUP, optionsGroupName)
 
         guard mysql_real_connect(cConnection, host, user, password, database, port, socket, flag) != nil else {
             throw Error.connection(error)


### PR DESCRIPTION
From [the documentation](http://dev.mysql.com/doc/refman/5.7/en/option-files.html): "Most MySQL programs can read startup options from option files (sometimes called configuration files). Option files provide a convenient way to specify commonly used options so that they need not be entered on the command line each time you run a program."

A simple change allows Vapor to read these files as well.

By default, Vapor will read the contents of the `[client]` group (which all client programs do) as well as the `[vapor]` group. Passing in an `optionsGroupName` to `init()` will cause it to read from that group instead of `[vapor]`.