### PR TITLE
Add optional inclusion of fractional seconds when converting into str…

### DIFF
--- a/Sources/MySQL/Bind+Node.swift
+++ b/Sources/MySQL/Bind+Node.swift
@@ -9,6 +9,7 @@
 #endif
 import Core
 import JSON
+import Foundation
 
 extension Bind {
     /**
@@ -105,10 +106,18 @@ extension Bind {
                 return .string("\(time.year.pad(4))-\(time.month.pad(2))-\(time.day.pad(2))")
             case MYSQL_TYPE_DATETIME, MYSQL_TYPE_TIMESTAMP:
                 let time = unwrap(buffer, MYSQL_TIME.self)
-                return .string("\(time.year.pad(4))-\(time.month.pad(2))-\(time.day.pad(2)) \(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))")
+                var string = "\(time.year.pad(4))-\(time.month.pad(2))-\(time.day.pad(2)) \(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))"
+                if Database.fractionalSecondsDigits > 0 {
+                    string += ".\(time.second_part.pad(Database.fractionalSecondsDigits))"
+                }
+                return .string(string)
             case MYSQL_TYPE_TIME:
                 let time = unwrap(buffer, MYSQL_TIME.self)
-                return .string("\(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))")
+                var string = "\(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))"
+                if Database.fractionalSecondsDigits > 0 {
+                    string += ".\(time.second_part.pad(Database.fractionalSecondsDigits))"
+                }
+                return .string(string)
             default:
                 print("[MySQL] Unsupported type: \(variant).")
                 return .null
@@ -132,6 +141,23 @@ extension UInt32 {
         return string
     }
 }
+
+extension UInt {
+    func pad(_ n: Int) -> String {
+        var string = description
+        
+        if string.characters.count >= n {
+            return string
+        }
+        
+        for _ in 0..<(n - string.characters.count) {
+            string = "0" + string
+        }
+        
+        return string
+    }
+}
+
 
 extension Sequence where Iterator.Element == UInt8 {
     var string: String {

--- a/Sources/MySQL/Bind+Node.swift
+++ b/Sources/MySQL/Bind+Node.swift
@@ -103,19 +103,19 @@ extension Bind {
                 return .number(.double(Double(float)))
             case MYSQL_TYPE_DATE:
                 let time = unwrap(buffer, MYSQL_TIME.self)
-                return .string("\(time.year.pad(4))-\(time.month.pad(2))-\(time.day.pad(2))")
+                return .string("\(UInt(time.year).pad(4))-\(UInt(time.month).pad(2))-\(UInt(time.day).pad(2))")
             case MYSQL_TYPE_DATETIME, MYSQL_TYPE_TIMESTAMP:
                 let time = unwrap(buffer, MYSQL_TIME.self)
-                var string = "\(time.year.pad(4))-\(time.month.pad(2))-\(time.day.pad(2)) \(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))"
-                if Database.fractionalSecondsDigits > 0 {
-                    string += ".\(time.second_part.pad(Database.fractionalSecondsDigits))"
+                var string = "\(UInt(time.year).pad(4))-\(UInt(time.month).pad(2))-\(UInt(time.day).pad(2)) \(UInt(time.hour).pad(2)):\(UInt(time.minute).pad(2)):\(UInt(time.second).pad(2))"
+                if self.subSecondResolution > 0 {
+                    string += ".\(time.second_part.pad(self.subSecondResolution))"
                 }
                 return .string(string)
             case MYSQL_TYPE_TIME:
                 let time = unwrap(buffer, MYSQL_TIME.self)
-                var string = "\(time.hour.pad(2)):\(time.minute.pad(2)):\(time.second.pad(2))"
-                if Database.fractionalSecondsDigits > 0 {
-                    string += ".\(time.second_part.pad(Database.fractionalSecondsDigits))"
+                var string = "\(UInt(time.hour).pad(2)):\(UInt(time.minute).pad(2)):\(UInt(time.second).pad(2))"
+                if self.subSecondResolution > 0 {
+                    string += ".\(time.second_part.pad(self.subSecondResolution))"
                 }
                 return .string(string)
             default:
@@ -123,22 +123,6 @@ extension Bind {
                 return .null
             }
         }
-    }
-}
-
-extension UInt32 {
-    func pad(_ n: Int) -> String {
-        var string = description
-
-        if string.characters.count >= n {
-            return string
-        }
-
-        for _ in 0..<(n - string.characters.count) {
-            string = "0" + string
-        }
-
-        return string
     }
 }
 

--- a/Sources/MySQL/Bind.swift
+++ b/Sources/MySQL/Bind.swift
@@ -46,6 +46,10 @@ public final class Bind {
         self.cBind = cBind
     }
     
+    /** 
+        
+    */
+    public var subSecondResolution: Int = -1
     /**
         Creates an output binding from an expected Field.
     */

--- a/Sources/MySQL/Binds.swift
+++ b/Sources/MySQL/Binds.swift
@@ -22,8 +22,9 @@ public final class Binds {
         Creastes an array of input bindings
         from values.
     */
-    public convenience init(_ values: [NodeRepresentable]) throws {
+    public convenience init(_ values: [NodeRepresentable], subSecondResolution: Int) throws {
         let binds = try values.map { try $0.makeNode().bind }
+        for bind in binds { bind.subSecondResolution = subSecondResolution }
         self.init(binds)
     }
 
@@ -32,11 +33,12 @@ public final class Binds {
         Creates an array of output bindings
         from expected Fields.
     */
-    public convenience init(_ fields: Fields) {
+    public convenience init(_ fields: Fields, subSecondResolution: Int) {
         var binds: [Bind] = []
 
         for field in fields.fields {
             let bind = Bind(field)
+            bind.subSecondResolution = subSecondResolution
             binds.append(bind)
         }
 

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -23,6 +23,8 @@ public final class Connection {
     public let cConnection: CConnection
 
     private let lock = Lock()
+    
+    private let subSecondResolution: Int
 
     public init(
         host: String,
@@ -33,8 +35,11 @@ public final class Connection {
         socket: String?,
         flag: UInt,
         encoding: String,
-        optionsGroupName: String = "vapor"
+        optionsGroupName: String = "vapor",
+        subSecondResolution: Int
     ) throws {
+        self.subSecondResolution = subSecondResolution
+        
         mysql_thread_init()
         cConnection = mysql_init(nil)
 
@@ -69,7 +74,7 @@ public final class Connection {
 
             // Transforms the `[Value]` array into bindings
             // and applies those bindings to the statement.
-            let inputBinds = try Binds(values)
+            let inputBinds = try Binds(values, subSecondResolution: subSecondResolution)
             guard mysql_stmt_bind_param(statement, inputBinds.cBinds) == 0 else {
                 throw Error.inputBind(error)
             }
@@ -93,7 +98,7 @@ public final class Connection {
                 // Use the fields data to create output bindings.
                 // These act as buffers for the data that will
                 // be returned when the statement is executed.
-                let outputBinds = Binds(fields)
+                let outputBinds = Binds(fields, subSecondResolution: subSecondResolution)
 
                 // Bind the output bindings to the statement.
                 guard mysql_stmt_bind_result(statement, outputBinds.cBinds) == 0 else {

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -33,6 +33,8 @@ public final class Database {
          - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
             used, since "utf8" does not fully implement the UTF8 standard and does
             not support Unicode.
+        - parameter fractionalSecondsDigits: Usually 0 for no fractional seconds and up to 6 
+            for microsecond resolution
 
 
         - throws: `Error.connection(String)` if the call to
@@ -46,7 +48,8 @@ public final class Database {
         port: UInt = 3306,
         socket: String? = nil,
         flag: UInt = 0,
-        encoding: String = "utf8"
+        encoding: String = "utf8",
+        fractionalSecondsDigits: Int = 0
     ) throws {
         try Database.activeLock.locked {
             /// Initializes the server that will
@@ -64,6 +67,7 @@ public final class Database {
         self.socket = socket
         self.flag = flag
         self.encoding = encoding
+        Database.fractionalSecondsDigits = fractionalSecondsDigits
     }
 
     private let host: String
@@ -74,6 +78,7 @@ public final class Database {
     private let socket: String?
     private let flag: UInt
     private let encoding: String
+    public static var fractionalSecondsDigits: Int = 0
 
     static private var activeLock = Lock()
 

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -49,7 +49,7 @@ public final class Database {
         socket: String? = nil,
         flag: UInt = 0,
         encoding: String = "utf8",
-        subSecondResolution: Int
+        subSecondResolution: Int = 0
     ) throws {
         try Database.activeLock.locked {
             /// Initializes the server that will

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -33,7 +33,7 @@ public final class Database {
          - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
             used, since "utf8" does not fully implement the UTF8 standard and does
             not support Unicode.
-        - parameter fractionalSecondsDigits: Usually 0 for no fractional seconds and up to 6 
+        - parameter subSecondResolution: Usually 0 for no fractional seconds and up to 6
             for microsecond resolution
 
 
@@ -49,7 +49,7 @@ public final class Database {
         socket: String? = nil,
         flag: UInt = 0,
         encoding: String = "utf8",
-        fractionalSecondsDigits: Int = 0
+        subSecondResolution: Int
     ) throws {
         try Database.activeLock.locked {
             /// Initializes the server that will
@@ -67,7 +67,7 @@ public final class Database {
         self.socket = socket
         self.flag = flag
         self.encoding = encoding
-        Database.fractionalSecondsDigits = fractionalSecondsDigits
+        self.subSecondResolution = subSecondResolution
     }
 
     private let host: String
@@ -78,7 +78,7 @@ public final class Database {
     private let socket: String?
     private let flag: UInt
     private let encoding: String
-    public static var fractionalSecondsDigits: Int = 0
+    private let subSecondResolution: Int
 
     static private var activeLock = Lock()
 
@@ -124,7 +124,8 @@ public final class Database {
             port: port,
             socket: socket,
             flag: flag,
-            encoding: encoding
+            encoding: encoding,
+            subSecondResolution: subSecondResolution
         )
     }
 


### PR DESCRIPTION
…ing values

MySQL supports fractional seconds when using fields like DATETIME(6), where the '6' represents the resolution of the fractional seconds stored.

This commit allows the database to be initialized with a constant to be used to allow all TIME/DATETIME/TIMESTAMP values to be converted into a string with this same resolution. 

MySQL current does not implement the API to provide the information about the field at run-time to extract a per-field resolution for this value.