### PR TITLE
Open up encoding constant

### DIFF
--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -73,7 +73,7 @@ public final class Database {
     private let port: UInt32
     private let socket: String?
     private let flag: UInt
-    private let encoding: String
+    public let encoding: String
 
     static private var activeLock = Lock()
 


### PR DESCRIPTION
Opening up the encoding constant should offer a bit more flexibility in the `mysql-driver` to fix e.g. this TODO: https://github.com/vapor/mysql-driver/blob/master/Sources/FluentMySQL/MySQLSerializer.swift#L17