### PR TITLE
execute() to run iteratively instead of returning all results at once

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -47,7 +47,6 @@ public final class Connection {
         mysql_set_character_set(cConnection, encoding)
     }
 
-    @discardableResult
     public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ iterator: (([String: Node]) -> Void)? = nil) throws {
         try lock.locked {
             // Create a pointer to the statement

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -17,18 +17,18 @@ public final class Database {
     /**
         Attempts to establish a connection to a MySQL database
         engine running on host.
-     
+
         - parameter host: May be either a host name or an IP address.
             If host is the string "localhost", a connection to the local host is assumed.
         - parameter user: The user's MySQL login ID.
         - parameter password: Password for user.
-        - parameter database: Database name. 
+        - parameter database: Database name.
             The connection sets the default database to this value.
-        - parameter port: If port is not 0, the value is used as 
+        - parameter port: If port is not 0, the value is used as
             the port number for the TCP/IP connection.
-        - parameter socket: If socket is not NULL, 
+        - parameter socket: If socket is not NULL,
             the string specifies the socket or named pipe to use.
-        - parameter flag: Usually 0, but can be set to a combination of the 
+        - parameter flag: Usually 0, but can be set to a combination of the
             flags at http://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html
          - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
             used, since "utf8" does not fully implement the UTF8 standard and does
@@ -79,13 +79,13 @@ public final class Database {
 
     /**
         Executes the MySQL query string with parameterized values.
-     
+
         - parameter query: MySQL flavored SQL query string.
         - parameter values: Array of MySQL values to be parameterized.
             The number of Values MUST equal the number of `?` in the query string.
-     
+
         - throws: Various `Database.Error` types.
-     
+
         - returns: An array of `[String: Value]` results.
             May be empty if the call does not produce data.
     */
@@ -100,7 +100,40 @@ public final class Database {
             connection = try makeConnection()
         }
 
-        return try connection.execute(query, values)
+        var results: [[String: Node]] = []
+        try connection.execute(query, values) {
+          results.append($0)
+        }
+        return results
+    }
+
+
+    /**
+        Executes the MySQL query string with parameterized values and calls a
+        closure for each result.
+
+        - parameter query: MySQL flavored SQL query string.
+        - parameter values: Array of MySQL values to be parameterized.
+            The number of Values MUST equal the number of `?` in the query string.
+        - parameter iterator: Closure which is called for each row in the query
+            results with a `[String: Value]` dictionary. May not be called at
+            all if there are zero results.
+
+        - throws: Various `Database.Error` types.
+
+    */
+    @discardableResult
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil, _ iterator: (@escaping ([String: Node]) -> Void)) throws {
+        // If not connection is supplied, make a new one.
+        // This makes thread-safety default.
+        let connection: Connection
+        if let c = on {
+            connection = c
+        } else {
+            connection = try makeConnection()
+        }
+
+        try connection.execute(query, values, iterator)
     }
 
 

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -8,6 +8,11 @@ class MySQLTests: XCTestCase {
         ("testSelectVersion", testSelectVersion),
         ("testTables", testTables),
         ("testParameterization", testParameterization),
+        ("testJSON", testJSON),
+        ("testTimestamps", testTimestamps),
+        ("testSpam", testSpam),
+        ("testSpamIterator", testSpamIterator),
+        ("testError", testError),
     ]
 
     var mysql: MySQL.Database!
@@ -186,6 +191,24 @@ class MySQLTests: XCTestCase {
         } catch {
             XCTFail("Testing multiple failed: \(error)")
         }
+    }
+
+    func testSpamIterator() {
+      do {
+          let c = try mysql.makeConnection()
+
+          try c.execute("DROP TABLE IF EXISTS spam")
+          try c.execute("CREATE TABLE spam (s VARCHAR(64), time TIME)")
+
+          for _ in 0..<10_000 {
+              try c.execute("INSERT INTO spam VALUES (?, ?)", ["hello", "13:42"])
+          }
+
+          let cn = try mysql.makeConnection()
+          try cn.execute("SELECT * FROM spam") { _ in }
+      } catch {
+          XCTFail("Testing multiple with iterator failed: \(error)")
+      }
     }
 
     func testError() {


### PR DESCRIPTION
# The problem

Currently, `Connection.execute()` is one large function which prepares a statement, executes it, iterates through the results set (with `mysql_stmt_fetch()`), converts the results to Nodes and returns the whole lot in memory as `[[String: Node]]`.

This means that the maximum size of the result set which can be handled is limited by the available system memory.

# My solution

A better option is to return each row as it comes in a closure:

```swift
try database.execute(query, values) { resultNode in
  // handle resultNode
}
```

# Benchmark

Here is a comparison of the amount of memory used by the two methods using data sets of 2,000 and 40,000 rows of production data:

| Method | 2,000 rows | 40,000 rows |
| - | - | - |
| All results | 44 MB | 294 MB |
| Iterating | 31 MB | 31 MB |

And the time taken:

| Method | 2,000 rows | 40,000 rows |
| - | - | - |
| All results | 2.53 s | 46.64 s |
| Iterating | 2.54 s | 44.51 s |

It can be seen that the iterative method uses no additional memory for large data sets, and does not increase the amount of time taken to process.

# Impact on code

As we have just hit a 1.2 release, I have tried to minimise changes to the public API.

* Fluent: no change to API, no change to behaviour, no way to opt-in to new behaviour.

* `Database` class: no change to existing API. Opt-in to new behaviour.

* `Connection` class: API of `execute()` function changes for `SELECT` queries only. Instead of returning a result set, a closure should be provided. If no result is expected, no closure is required, and there is no change to code.

The majority of users will interact with this library through Fluent. For them, there will be no change to behaviour.

Some users may also make use of `Database.execute()` or `Database.raw()` to make queries. There will be no change to this code required either.

If a user has dropped all the way down to the `Connection` class to execute a query and return a result, then they will be affected by this change.

## Future impact

Ideally, it would be good for this behaviour to bubble up Vapor's stack so that it becomes used by default, however as this would be a breaking change I have not touched it yet.