### PR TITLE
Add iterating result option for Connection and Database

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -43,13 +43,11 @@ public final class Connection {
         guard mysql_real_connect(cConnection, host, user, password, database, port, socket, flag) != nil else {
             throw Error.connection(error)
         }
-        
+
         mysql_set_character_set(cConnection, encoding)
     }
 
-    @discardableResult
-    public func execute(_ query: String, _ values: [NodeRepresentable] = []) throws -> [[String: Node]] {
-        var returnable: [[String: Node]] = []
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ iterator: (([String: Node]) -> Void)? = nil) throws {
         try lock.locked {
             // Create a pointer to the statement
             // This should only fail if memory is limited.
@@ -106,8 +104,6 @@ public final class Connection {
                     throw Error.execute(error)
                 }
 
-                var results: [[String: Node]] = []
-
                 // Iterate over all of the rows that are returned.
                 // `mysql_stmt_fetch` will continue to return `0`
                 // as long as there are rows to be fetched.
@@ -125,7 +121,9 @@ public final class Connection {
 
                     }
 
-                    results.append(parsed)
+                    // Call the `iterator` closure with this row's results,
+                    // if one was provided.
+                    iterator?(parsed)
 
                     // reset the bindings onto the statement to
                     // signal that they may be reused as buffers
@@ -134,18 +132,23 @@ public final class Connection {
                         throw Error.outputBind(error)
                     }
                 }
-                
-                returnable = results
+
             } else {
                 // no data is expected to return from
                 // this query, simply execute it.
                 guard mysql_stmt_execute(statement) == 0 else {
                     throw Error.execute(error)
                 }
-                returnable = []
             }
         }
+    }
 
+    @discardableResult
+    public func execute(_ query: String, _ values: [NodeRepresentable] = []) throws -> [[String: Node]] {
+        var returnable: [[String: Node]] = []
+        try execute(query, values) {
+            returnable.append($0)
+        }
         return returnable
     }
 
@@ -165,6 +168,5 @@ public final class Connection {
         }
         return String(cString: error)
     }
-    
-}
 
+}

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -47,7 +47,7 @@ public final class Connection {
         mysql_set_character_set(cConnection, encoding)
     }
 
-    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ iterator: (([String: Node]) -> Void)? = nil) throws {
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ iterator: (([String: Node]) -> Void) = { _ in }) throws {
         try lock.locked {
             // Create a pointer to the statement
             // This should only fail if memory is limited.
@@ -123,7 +123,7 @@ public final class Connection {
 
                     // Call the `iterator` closure with this row's results,
                     // if one was provided.
-                    iterator?(parsed)
+                    iterator(parsed)
 
                     // reset the bindings onto the statement to
                     // signal that they may be reused as buffers

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -91,7 +91,7 @@ public final class Database {
         - throws: Various `Database.Error` types.
 
     */
-    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil, _ iterator: (@escaping ([String: Node]) -> Void)) throws {
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil, _ iterator: (([String: Node]) -> Void) = { _ in }) throws {
         // If not connection is supplied, make a new one.
         // This makes thread-safety default.
         let connection: Connection

--- a/Sources/MySQL/Database.swift
+++ b/Sources/MySQL/Database.swift
@@ -17,18 +17,18 @@ public final class Database {
     /**
         Attempts to establish a connection to a MySQL database
         engine running on host.
-     
+
         - parameter host: May be either a host name or an IP address.
             If host is the string "localhost", a connection to the local host is assumed.
         - parameter user: The user's MySQL login ID.
         - parameter password: Password for user.
-        - parameter database: Database name. 
+        - parameter database: Database name.
             The connection sets the default database to this value.
-        - parameter port: If port is not 0, the value is used as 
+        - parameter port: If port is not 0, the value is used as
             the port number for the TCP/IP connection.
-        - parameter socket: If socket is not NULL, 
+        - parameter socket: If socket is not NULL,
             the string specifies the socket or named pipe to use.
-        - parameter flag: Usually 0, but can be set to a combination of the 
+        - parameter flag: Usually 0, but can be set to a combination of the
             flags at http://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html
          - parameter encoding: Usually "utf8", but something like "utf8mb4" may be
             used, since "utf8" does not fully implement the UTF8 standard and does
@@ -78,19 +78,20 @@ public final class Database {
     static private var activeLock = Lock()
 
     /**
-        Executes the MySQL query string with parameterized values.
-     
+        Executes the MySQL query string with parameterized values and calls a
+        closure for each result.
+
         - parameter query: MySQL flavored SQL query string.
         - parameter values: Array of MySQL values to be parameterized.
             The number of Values MUST equal the number of `?` in the query string.
-     
+        - parameter iterator: Closure which is called for each row in the query
+            results with a `[String: Value]` dictionary. May not be called at
+            all if there are zero results.
+
         - throws: Various `Database.Error` types.
-     
-        - returns: An array of `[String: Value]` results.
-            May be empty if the call does not produce data.
+
     */
-    @discardableResult
-    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil) throws -> [[String: Node]] {
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil, _ iterator: (@escaping ([String: Node]) -> Void)) throws {
         // If not connection is supplied, make a new one.
         // This makes thread-safety default.
         let connection: Connection
@@ -100,7 +101,29 @@ public final class Database {
             connection = try makeConnection()
         }
 
-        return try connection.execute(query, values)
+        try connection.execute(query, values, iterator)
+    }
+
+    /**
+        Executes the MySQL query string with parameterized values and returns
+        all results.
+
+        - parameter query: MySQL flavored SQL query string.
+        - parameter values: Array of MySQL values to be parameterized.
+            The number of Values MUST equal the number of `?` in the query string.
+
+        - throws: Various `Database.Error` types.
+
+        - returns: An array of `[String: Value]` results.
+            May be empty if the call does not produce data.
+    */
+    @discardableResult
+    public func execute(_ query: String, _ values: [NodeRepresentable] = [], _ on: Connection? = nil) throws -> [[String: Node]] {
+        var returnable: [[String: Node]] = []
+        try execute(query, values, on) {
+            returnable.append($0)
+        }
+        return returnable
     }
 
 

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -10,6 +10,7 @@ class MySQLTests: XCTestCase {
         ("testParameterization", testParameterization),
         ("testTimestamps", testTimestamps),
         ("testSpam", testSpam),
+        ("testSpamIterator", testSpamIterator),
         ("testError", testError),
     ]
 
@@ -17,6 +18,18 @@ class MySQLTests: XCTestCase {
 
     override func setUp() {
         mysql = MySQL.Database.makeTestConnection()
+    }
+
+    override func tearDown() {
+        do {
+            try mysql.execute("DROP TABLE IF EXISTS foo")
+            try mysql.execute("DROP TABLE IF EXISTS parameterization")
+            try mysql.execute("DROP TABLE IF EXISTS json")
+            try mysql.execute("DROP TABLE IF EXISTS times")
+            try mysql.execute("DROP TABLE IF EXISTS spam")
+        } catch {
+            print("Did not drop all test tables")
+        }
     }
 
     func testSelectVersion() {
@@ -189,6 +202,24 @@ class MySQLTests: XCTestCase {
         } catch {
             XCTFail("Testing multiple failed: \(error)")
         }
+    }
+
+    func testSpamIterator() {
+      do {
+          let c = try mysql.makeConnection()
+
+          try c.execute("DROP TABLE IF EXISTS spam")
+          try c.execute("CREATE TABLE spam (s VARCHAR(64), time TIME)")
+
+          for _ in 0..<10_000 {
+              try c.execute("INSERT INTO spam VALUES (?, ?)", ["hello", "13:42"])
+          }
+
+          let cn = try mysql.makeConnection()
+          try cn.execute("SELECT * FROM spam") { _ in }
+      } catch {
+          XCTFail("Testing multiple with iterator failed: \(error)")
+      }
     }
 
     func testError() {


### PR DESCRIPTION
This is a remix of #75, re-jigged to cause no changes to public API.

# The problem

```swift
let results: [[String: Node]] = try database.execute(query, values)
// handle results
```


Currently, `Connection.execute()` is one large function which prepares a statement, executes it, iterates through the results set (with `mysql_stmt_fetch()`), converts the results to Nodes and returns the whole lot in memory as `[[String: Node]]`.

This means that the maximum size of the result set which can be handled is limited by the available system memory.

# My solution

A better option is to return each row as it comes in a closure:

```swift
try database.execute(query, values) { result in
  // handle result: [String: Node] before retrieving the next one
}
```

# Benchmark

Here is a comparison of the amount of memory used by the two methods using data sets of 2,000 and 40,000 rows of production data on a Ubuntu 16.04 installation:

| Method | 2,000 rows | 40,000 rows |
| - | - | - |
| All results | 44 MB | 294 MB |
| Iterating | 31 MB | 31 MB |

And the time taken:

| Method | 2,000 rows | 40,000 rows |
| - | - | - |
| All results | 2.53 s | 46.64 s |
| Iterating | 2.54 s | 44.51 s |

It can be seen that the iterative method uses no additional memory for large data sets, and does not increase the amount of time taken to process.

# Impact on code

There is no change to public API. When using the `Database` or `Connection` classes, the implementor is required to opt-in to using the iterative result method.

When using high-level Fluent methods, there is no way to opt-in to iterative behaviour. This can be addressed in a future PR to Fluent and the other database drivers.