### PR TITLE
Added Transaction to connection

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -47,7 +47,7 @@ public final class Connection {
         mysql_set_character_set(cConnection, encoding)
     }
     
-    public func transaction(_ closure: (Void) throws -> Void) throws {
+    public func transaction(_ closure: () throws -> Void) throws {
         // required by transactions, but I don't want to open the old
         // MySQL query API to the public as it would be a burden to maintain.
         func oldQuery(_ query: String) throws {

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -46,7 +46,31 @@ public final class Connection {
         
         mysql_set_character_set(cConnection, encoding)
     }
-
+    
+    public func transaction(_ closure: (Void) throws -> Void) throws {
+        // required by transactions, but I don't want to open the old
+        // MySQL query API to the public as it would be a burden to maintain.
+        func oldQuery(_ query: String) throws {
+            try lock.locked {
+                guard mysql_query(cConnection, query) == 0 else {
+                    throw Error.execute(error)
+                }
+            }
+        }
+        
+        try oldQuery("START TRANSACTION")
+        
+        do {
+            try closure()
+        } catch {
+            // rollback changes and then rethrow the error
+            try oldQuery("ROLLBACK")
+            throw error
+        }
+        
+        try oldQuery("COMMIT")
+    }
+    
     @discardableResult
     public func execute(_ query: String, _ values: [NodeRepresentable] = []) throws -> [[String: Node]] {
         var returnable: [[String: Node]] = []

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,8 @@ import XCTest
 @testable import MySQLTests
 
 XCTMain([
-    testCase(MySQLTests.allTests)
+    testCase(DateTests.allTests),
+    testCase(MySQLTests.allTests),
 ])
 
 #endif

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -238,8 +238,11 @@ class MySQLTests: XCTestCase {
             
             do {
                 try c.transaction {
+                    // will succeed, but will be rolled back
+                    try c.execute("UPDATE transaction SET name = 'Timmy'")
+                    
                     // malformed query, will throw
-                    try c.execute("UPDATE transaction STE name = 'Timmy'")
+                    try c.execute("💉")
                 }
                 
                 XCTFail("Transaction should have rethrown error.")


### PR DESCRIPTION
Added basic support for transactions. If one of the embedded calls fails the transaction will be rolled back and the error will be re-thrown. On success, the transaction will be committed.

```swift
try connection.transaction {
   try connection.execute(...)
}
```