### PR TITLE
Convert field names only once per query

### DIFF
--- a/Sources/MySQL/Field.swift
+++ b/Sources/MySQL/Field.swift
@@ -17,19 +17,14 @@ public final class Field {
 
     public let cField: CField
 
-    public var name: String {
-        var name: String = ""
-
-        let len = Int(cField.name_length)
-        cField.name.withMemoryRebound(to: Byte.self, capacity: len) { pointer in
-            let buff = UnsafeBufferPointer(start: pointer, count: Int(cField.name_length))
-            name = Array(buff).string
-        }
-
-        return name
-    }
+    public let name: String
 
     public init(_ cField: CField) {
         self.cField = cField
+        let len = Int(cField.name_length)
+        self.name = cField.name.withMemoryRebound(to: Byte.self, capacity: len) { pointer in
+            let buff = UnsafeBufferPointer(start: pointer, count: len)
+            return Array(buff).string
+        }
     }
 }


### PR DESCRIPTION
The Field.name getter is being called for every row fetched from the
database. Having it as a computed property is unnecessary overhead,
considering that the result set metadata may not change.

Turning it into precalculated property decreases query execution time
by ~40%.