### PR TITLE
Reuse the parsed dictionary during a query to reduce allocations

### DIFF
--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -131,13 +131,12 @@ public final class Connection {
                 }
 
                 var results: [[String: Node]] = []
+                var parsed: [String: Node] = [:]
 
                 // Iterate over all of the rows that are returned.
                 // `mysql_stmt_fetch` will continue to return `0`
                 // as long as there are rows to be fetched.
                 while mysql_stmt_fetch(statement) == 0 {
-                    var parsed: [String: Node] = [:]
-
                     // For each row, loop over all of the fields expected.
                     for (i, field) in fields.fields.enumerated() {
 

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -131,6 +131,9 @@ public final class Connection {
                 }
 
                 var results: [[String: Node]] = []
+
+                // This single dictionary is reused for all rows in the result set
+                // to avoid the runtime overhead of (de)allocating one per row.
                 var parsed: [String: Node] = [:]
 
                 // Iterate over all of the rows that are returned.


### PR DESCRIPTION
Xcode's time profiler shows that a distinguishable amount of time is
wasted by allocating/deallocating memory for every row.

Reusing the same dictionary reduces query time by 5% in my tests. The
change is trivial and safe, because all the values will be overwritten
by the for loop.