### PR TITLE
use `field.max_length` instead of `field.length`

### DIFF
--- a/Sources/MySQL/Bind/Bind.swift
+++ b/Sources/MySQL/Bind/Bind.swift
@@ -19,7 +19,7 @@ public final class Bind {
     /**
      The raw C binding.
      */
-    public let cBind: CBind
+    public var cBind: CBind
     
     /**
         Creates a binding from a raw C binding.
@@ -56,12 +56,13 @@ public final class Bind {
                  MYSQL_TYPE_TIME:
             length = MemoryLayout<MYSQL_TIME>.size
         default:
-            length = Int(field.cField.length)
+            length = Int(field.cField.max_length)
         }
 
         cBind.buffer_length = UInt(length)
-        
         cBind.buffer = UnsafeMutableRawPointer.allocate(bytes: length, alignedTo: MemoryLayout<Void>.alignment)
+        
+        
         cBind.length = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
         cBind.is_null = UnsafeMutablePointer<my_bool>.allocate(capacity: 1)
         cBind.error = UnsafeMutablePointer<my_bool>.allocate(capacity: 1)

--- a/Sources/MySQL/Bind/Bind.swift
+++ b/Sources/MySQL/Bind/Bind.swift
@@ -19,7 +19,7 @@ public final class Bind {
     /**
      The raw C binding.
      */
-    public var cBind: CBind
+    public let cBind: CBind
     
     /**
         Creates a binding from a raw C binding.

--- a/Sources/MySQL/Bind/Binds.swift
+++ b/Sources/MySQL/Bind/Binds.swift
@@ -5,8 +5,8 @@ import CMySQL
 public final class Binds {
     public typealias CBinds = UnsafeMutablePointer<Bind.CBind>
 
-    public let cBinds: CBinds
-    public let binds: [Bind]
+    public var cBinds: CBinds
+    public var binds: [Bind]
 
     /// Creastes an array of input bindings
     /// from values.

--- a/Sources/MySQL/Bind/Binds.swift
+++ b/Sources/MySQL/Bind/Binds.swift
@@ -5,8 +5,8 @@ import CMySQL
 public final class Binds {
     public typealias CBinds = UnsafeMutablePointer<Bind.CBind>
 
-    public var cBinds: CBinds
-    public var binds: [Bind]
+    public let cBinds: CBinds
+    public let binds: [Bind]
 
     /// Creastes an array of input bindings
     /// from values.

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -110,10 +110,10 @@ public final class Connection {
             guard mysql_stmt_execute(statement) == 0 else {
                 throw lastError
             }
-            
+
             return .null
         }
-        
+
         defer {
             mysql_free_result(metadata)
         }
@@ -133,19 +133,19 @@ public final class Connection {
         // important! field information should not be parsed
         // until mysql_stmt_store_result has been called.
         let fields = try Fields(metadata, self)
-        
+
         // Use the fields data to create output bindings.
         // These act as buffers for the data that will
         // be returned when the statement is executed.
         let outputBinds = Binds(fields)
-        
+
         // Bind the output bindings to the statement.
         guard mysql_stmt_bind_result(statement, outputBinds.cBinds) == 0 else {
             throw lastError
         }
-        
+
         var results: [StructuredData] = []
-        
+
         // This single dictionary is reused for all rows in the result set
         // to avoid the runtime overhead of (de)allocating one per row.
         var parsed: [String: StructuredData] = [:]

--- a/Sources/MySQL/Connection.swift
+++ b/Sources/MySQL/Connection.swift
@@ -101,7 +101,7 @@ public final class Connection {
         guard mysql_stmt_bind_param(statement, inputBinds.cBinds) == 0 else {
             throw lastError
         }
-        
+
         // Fetches metadata from the statement which has
         // not yet run.
         guard let metadata = mysql_stmt_result_metadata(statement) else {


### PR DESCRIPTION
This changes the MySQL result buffer to only allocate enough memory to hold the largest actual result, instead of allocating enough memory to hold the largest _theoretical_ result.

This should prevent issues with using `LONGTEXT` columns on machines with limited RAM. (Unless of course there is actually a huge amount of data stored in one of these columns).

Result buffers (binds) are now created _after_ the results have been stored client side (in the libraries internal buffers). This important re-ordering of events is what allows us to create our result buffers after the `max_length` is known.