### PR TITLE
Add support for SMALLINT/MYSQL_TYPE_SHORT

### DIFF
--- a/Sources/MySQL/Bind/Bind+Node.swift
+++ b/Sources/MySQL/Bind/Bind+Node.swift
@@ -77,6 +77,14 @@ extension Bind {
                     let int = unwrap(buffer, Int32.self)
                     return .number(.int(Int(int)))
                 }
+            case MYSQL_TYPE_SHORT:
+                if cBind.is_unsigned == 1 {
+                    let uint = unwrap(buffer, UInt16.self)
+                    return .number(.uint(UInt(uint)))
+                } else {
+                    let int = unwrap(buffer, Int16.self)
+                    return .number(.int(Int(int)))
+                }
             case MYSQL_TYPE_TINY:
                 if cBind.is_unsigned == 1 {
                     let uint = unwrap(buffer, UInt8.self)


### PR DESCRIPTION
As previously raised in #57.

Fluent already has the ability to [create](https://github.com/vapor/mysql-driver/blob/master/Sources/MySQLDriver/Creator%2BMySQLTypes.swift#L83) and save to `SMALLINT` columns. This PR allows Fluent to read back from them as well.