### PR TITLE
Fixing packet sequenceId bug and incorrect incoming packet lengh calculations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,22 +8,22 @@ let package = Package(
     ],
     dependencies: [
         // Swift Promises, Futures, and Streams.
-        .package(url: "https://github.com/vapor/async.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/async.git", .exact("1.0.0-beta.1")),
 
         // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/core.git", .exact("3.0.0-beta.1")),
 
         // Cryptography modules
-        .package(url: "https://github.com/vapor/crypto.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/crypto.git", .exact("3.0.0-beta.1")),
         
         // Networking
-        .package(url: "https://github.com/vapor/sockets.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/sockets.git", .exact("3.0.0-beta.1")),
 
         // SSL support
-        .package(url: "https://github.com/vapor/tls.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/tls.git", .exact("3.0.0-beta.1")),
 
         // Non-blocking networking for Swift (HTTP and WebSockets).
-        .package(url: "https://github.com/vapor/engine.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/engine.git", .exact("3.0.0-beta.1")),
     ],
     targets: [
         .target(name: "MySQL", dependencies: ["CodableKit", "Crypto", "TCP", "TLS"]),

--- a/Sources/MySQL/Connection/Connection.swift
+++ b/Sources/MySQL/Connection/Connection.swift
@@ -16,7 +16,7 @@ public struct MySQLSSLConfig {
     }
 }
 
-/// A connectio to a MySQL database servers
+/// A connection to a MySQL database servers
 public struct MySQLConnection {
     let stateMachine: MySQLStateMachine
     

--- a/Sources/MySQL/Connection/PacketParser.swift
+++ b/Sources/MySQL/Connection/PacketParser.swift
@@ -129,9 +129,9 @@ internal struct MySQLPacketParser: ByteParser {
     fileprivate func parseHeader(from buffer: ByteBuffer) -> Int? {
         guard buffer.count >= 3 else { return nil }
         
-        let byte0 = UInt32(numericCast(buffer[0]))
-        let byte1 = UInt32(numericCast(buffer[1])) << 8
-        let byte2 = UInt32(numericCast(buffer[2])) << 16
+        let byte0: UInt32 = numericCast(buffer[0])
+        let byte1: UInt32 = numericCast(buffer[1]) << 8
+        let byte2: UInt32 = numericCast(buffer[2]) << 16
         
         return numericCast(byte0 | byte1 | byte2) as Int
     }

--- a/Sources/MySQL/Connection/PacketParser.swift
+++ b/Sources/MySQL/Connection/PacketParser.swift
@@ -129,9 +129,9 @@ internal struct MySQLPacketParser: ByteParser {
     fileprivate func parseHeader(from buffer: ByteBuffer) -> Int? {
         guard buffer.count >= 3 else { return nil }
         
-        let byte0: UInt32 = numericCast(buffer[0])
-        let byte1: UInt32 = numericCast(buffer[1])
-        let byte2: UInt32 = numericCast(buffer[2])
+        let byte0: UInt32 = (numericCast(buffer[0]) as UInt32).littleEndian
+        let byte1: UInt32 = (numericCast(buffer[1]) as UInt32).littleEndian << 8
+        let byte2: UInt32 = (numericCast(buffer[2]) as UInt32).littleEndian << 16
         
         return numericCast(byte0 | byte1 | byte2) as Int
     }

--- a/Sources/MySQL/Connection/PacketParser.swift
+++ b/Sources/MySQL/Connection/PacketParser.swift
@@ -129,9 +129,9 @@ internal struct MySQLPacketParser: ByteParser {
     fileprivate func parseHeader(from buffer: ByteBuffer) -> Int? {
         guard buffer.count >= 3 else { return nil }
         
-        let byte0: UInt32 = (numericCast(buffer[0]) as UInt32).littleEndian
-        let byte1: UInt32 = (numericCast(buffer[1]) as UInt32).littleEndian << 8
-        let byte2: UInt32 = (numericCast(buffer[2]) as UInt32).littleEndian << 16
+        let byte0 = UInt32(numericCast(buffer[0]))
+        let byte1 = UInt32(numericCast(buffer[1])) << 8
+        let byte2 = UInt32(numericCast(buffer[2])) << 16
         
         return numericCast(byte0 | byte1 | byte2) as Int
     }
@@ -157,16 +157,16 @@ internal struct MySQLPacketParser: ByteParser {
         // Take the cached previous packet edge-case bytes into consideration
         switch headerBytes.count {
         case 1:
-            byte0 = (numericCast(headerBytes[0]) as UInt32).littleEndian
+            byte0 = numericCast(headerBytes[0])
             
-            byte1 = (numericCast(pointer[0]) as UInt32).littleEndian << 8
-            byte2 = (numericCast(pointer[1]) as UInt32).littleEndian << 16
+            byte1 = numericCast(pointer[0]) << 8
+            byte2 = numericCast(pointer[1]) << 16
             parsed = 2
         case 2:
-            byte0 = (numericCast(headerBytes[0]) as UInt32).littleEndian
-            byte1 = (numericCast(headerBytes[1]) as UInt32).littleEndian << 8
+            byte0 = numericCast(headerBytes[0])
+            byte1 = numericCast(headerBytes[1]) << 8
             
-            byte2 = (numericCast(pointer[0]) as UInt32).littleEndian << 16
+            byte2 = numericCast(pointer[0]) << 16
             parsed = 1
         default:
             fatalError("Invalid MySQL parsing scenario reached")

--- a/Sources/MySQL/Internals/Handshake.swift
+++ b/Sources/MySQL/Internals/Handshake.swift
@@ -46,7 +46,12 @@ extension Packet {
         
         // Require decimal `10` to be the protocol version
         guard try parser.byte() == 10 else {
-            throw MySQLError(.invalidHandshake)
+            // if the first byte is 0xff then we got an error packet
+            if(parser.payload[0] == 0xff){
+                throw MySQLError(packet: self)
+            } else {
+                throw MySQLError(.invalidHandshake)
+            }
         }
         
         // UTF-8

--- a/Sources/MySQL/Internals/Handshake.swift
+++ b/Sources/MySQL/Internals/Handshake.swift
@@ -47,7 +47,7 @@ extension Packet {
         // Require decimal `10` to be the protocol version
         guard try parser.byte() == 10 else {
             // if the first byte is 0xff then we got an error packet
-            if(parser.payload[0] == 0xff){
+            if parser.payload[0] == 0xff {
                 throw MySQLError(packet: self)
             } else {
                 throw MySQLError(.invalidHandshake)

--- a/Sources/MySQL/Internals/MySQLStream.swift
+++ b/Sources/MySQL/Internals/MySQLStream.swift
@@ -14,6 +14,7 @@ final class MySQLStateMachine {
     var affectedRows: UInt64?
     
     var handshake: Handshake?
+    /// We currently don't use sequenceId
     var sequenceId: UInt8
     private let ssl: MySQLSSLConfig?
     let connected = Promise<Void>()

--- a/Sources/MySQL/Internals/Packet.swift
+++ b/Sources/MySQL/Internals/Packet.swift
@@ -96,7 +96,7 @@ internal final class Packet: ExpressibleByArrayLiteral {
        
         memcpy(pointer.advanced(by: 3), &sequenceId, 1)
         
-        memcpy(pointer.advanced(by: 1), elements, elements.count)
+        memcpy(pointer.advanced(by: 4), elements, elements.count)
         
         self.init(payload: MutableByteBuffer(start: pointer, count: 4 &+ elements.count), containsPacketSize: true)
     }
@@ -114,7 +114,7 @@ internal final class Packet: ExpressibleByArrayLiteral {
         
         memcpy(pointer.advanced(by: 3), &sequenceId, 1)
         
-        memcpy(pointer.advanced(by: 1), data, data.count)
+        memcpy(pointer.advanced(by: 4), data, data.count)
         
         self.init(payload: MutableByteBuffer(start: pointer, count: 4 &+ data.count), containsPacketSize: true)
     }
@@ -134,7 +134,7 @@ internal final class Packet: ExpressibleByArrayLiteral {
         memcpy(pointer.advanced(by: 3), &sequenceId, 1)
         
         data.withByteBuffer { buffer in
-            _ = memcpy(pointer.advanced(by: 1), buffer.baseAddress!, data.count)
+            _ = memcpy(pointer.advanced(by: 4), buffer.baseAddress!, data.count)
         }
         
         self.init(payload: MutableByteBuffer(start: pointer, count: 4 &+ data.count), containsPacketSize: true)

--- a/Sources/MySQL/Internals/Packet.swift
+++ b/Sources/MySQL/Internals/Packet.swift
@@ -90,7 +90,7 @@ internal final class Packet: ExpressibleByArrayLiteral {
             UInt8((elements.count >> 8) & 0xff),
             UInt8((elements.count >> 16) & 0xff),
         ]
-        let sequenceId = UInt8(0)
+        var sequenceId = UInt8(0)
 
         memcpy(pointer, packetSizeBytes, 3)
        
@@ -109,7 +109,7 @@ internal final class Packet: ExpressibleByArrayLiteral {
             UInt8((data.count >> 8) & 0xff),
             UInt8((data.count >> 16) & 0xff),
             ]
-        let sequenceId = UInt8(0)
+        var  sequenceId = UInt8(0)
         memcpy(pointer, packetSizeBytes, 3)
         
         memcpy(pointer.advanced(by: 3), &sequenceId, 1)
@@ -127,14 +127,14 @@ internal final class Packet: ExpressibleByArrayLiteral {
             UInt8((data.count >> 8) & 0xff),
             UInt8((data.count >> 16) & 0xff),
         ]
-        let sequenceId = UInt8(0)
+        var sequenceId = UInt8(0)
         
         memcpy(pointer, packetSizeBytes, 3)
         
         memcpy(pointer.advanced(by: 3), &sequenceId, 1)
         
         data.withByteBuffer { buffer in
-            memcpy(pointer.advanced(by: 1), buffer.baseAddress!, data.count)
+            _ = memcpy(pointer.advanced(by: 1), buffer.baseAddress!, data.count)
         }
         
         self.init(payload: MutableByteBuffer(start: pointer, count: 4 &+ data.count), containsPacketSize: true)

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   macos:
     macos:
-      xcode: "9.0"
+      xcode: "9.2"
     steps:
       - run: brew install mysql
       - run: brew services start mysql
@@ -15,7 +15,7 @@ jobs:
 
   linux:
     docker:
-      - image: swift:4.0
+      - image: norionomura/swift:swift-4.1-branch
       - image: mysql:5.7
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ jobs:
 
   linux:
     docker:
+      - image: norionomura/swift:swift-4.1-branch
       - image: mysql:5.7
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -22,7 +23,6 @@ jobs:
           # MYSQL_ROOT_HOST: %
           MYSQL_USER: root
           # MYSQL_PASSWORD: vapor
-      - image: norionomura/swift:swift-4.1-branch
     steps:
       - run: apt-get update
       - run: apt-get install -yq libssl-dev

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,6 @@ jobs:
 
   linux:
     docker:
-      - image: norionomura/swift:swift-4.1-branch
       - image: mysql:5.7
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -23,7 +22,9 @@ jobs:
           # MYSQL_ROOT_HOST: %
           MYSQL_USER: root
           # MYSQL_PASSWORD: vapor
+      - image: norionomura/swift:swift-4.1-branch
     steps:
+      - run: apt-get update
       - run: apt-get install -yq libssl-dev
       - checkout
       - run: swift build


### PR DESCRIPTION
Hi,

1. The outgoing packet sequenceId was broken, it got optimized out  from the source, so when it allocates packet the sequenceid field (4. byte of the buffer) contains random data. This PR fix this and set it to zero. I don't touch the handshake sequenceid generation where it is used (yet). 
Later on the packet fragmentation needs to be adressed thought because the servers are using this even when it  has no practical usage. 

2. The incoming packet length was incorrectly calculated, therefore all packets bigger than 255 byte likely causing memory errors

3. fixing dependencies to beta.1 tag
