### PR TITLE
Add support for .bit & .timestamp, add decode case for .string

### DIFF
--- a/Sources/MySQL/Parsing/Row+Parsing.swift
+++ b/Sources/MySQL/Parsing/Row+Parsing.swift
@@ -112,7 +112,6 @@ extension Parser {
                 return .double(Double(bitPattern: num))
             case .null:
                 return .null
-            case .timestamp: throw MySQLError(.unsupported, source: .capture())
             case .longlong:
                 let num = try self.parseUInt64()
                 
@@ -124,7 +123,7 @@ extension Parser {
             case .int24: throw MySQLError(.unsupported, source: .capture())
             case .date: throw MySQLError(.unsupported, source: .capture())
             case .time: throw MySQLError(.unsupported, source: .capture())
-            case .datetime:
+            case .datetime, .timestamp:
                 let format = try byte()
                 
                 let year = try parseUInt16()
@@ -161,7 +160,13 @@ extension Parser {
             case .newdate: throw MySQLError(.unsupported, source: .capture())
             case .varchar:
                 return .varChar(try self.parseLenEncString())
-            case .bit: throw MySQLError(.unsupported, source: .capture())
+            case .bit:
+                let length = try byte()
+                if length > 8 {
+                    throw MySQLError(.unsupported, source: .capture())
+                }
+                let value = try byte()
+                return .uint8(value)
             case .json: throw MySQLError(.unsupported, source: .capture())
             case .newdecimal: throw MySQLError(.unsupported, source: .capture())
             case .enum: throw MySQLError(.unsupported, source: .capture())

--- a/Sources/MySQL/Parsing/RowDecoder.swift
+++ b/Sources/MySQL/Parsing/RowDecoder.swift
@@ -66,6 +66,8 @@ final class RowDecoder : DecoderHelper {
     func decode(_ type: Column) throws -> String {
         if case .varString(let string) = type {
             return string
+        }else if case .string(let string) = type {
+            return string
         } else if case .blob(let data) = type {
             guard let string = String(data: data, encoding: .utf8) else {
                 throw CodableDecodingError.incorrectValue

--- a/Sources/MySQL/Parsing/RowDecoder.swift
+++ b/Sources/MySQL/Parsing/RowDecoder.swift
@@ -66,7 +66,7 @@ final class RowDecoder : DecoderHelper {
     func decode(_ type: Column) throws -> String {
         if case .varString(let string) = type {
             return string
-        }else if case .string(let string) = type {
+        } else if case .string(let string) = type {
             return string
         } else if case .blob(let data) = type {
             guard let string = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
Why:

MySQL types .bit and .timstamp were not supported

How:

Added case in the parser for .bit by assuming length was never > 1 byte
Added case in the parser for .timestamp using the same parser as .date