### PR TITLE
Support for Emoticons Unicode

### DIFF
--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -9,7 +9,7 @@ extension MySQLConnection {
     ///     - database: The database to select.
     ///     - password: Password for the user specified by `username`.
     /// - returns: A future that will complete when the authenticate is finished.
-    public func authenticate(username: String, database: String, password: String? = nil) -> Future<Void> {
+    public func authenticate(username: String, database: String, password: String? = nil, characterSet: MySQLCharacterSet = .utf8_general_ci) -> Future<Void> {
         var handshake: MySQLHandshakeV10?
         return send([]) { message in
             switch message {
@@ -51,7 +51,7 @@ extension MySQLConnection {
                     CLIENT_DEPRECATE_EOF
                 ],
                 maxPacketSize: 1_024,
-                characterSet: 0x21,
+                characterSet: characterSet,
                 username: username,
                 authResponse: authResponse,
                 database: database,

--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -24,23 +24,24 @@ extension MySQLConnection {
             }
             let authPlugin = handshake.authPluginName ?? "none"
             let authResponse: Data
-            switch authPlugin {
-            case "mysql_native_password":
-                guard let password = password else {
-                    throw MySQLError(identifier: "password", reason: "Password required for auth plugin.", source: .capture())
+            if let password = password, password.lengthOfBytes(using: .utf8) > 0 {
+                switch authPlugin {
+                case "mysql_native_password":
+                    guard handshake.authPluginData.count >= 20 else {
+                        throw MySQLError(identifier: "salt", reason: "Server-supplied salt too short.", source: .capture())
+                    }
+                    let salt = Data(handshake.authPluginData[..<20])
+                    let passwordHash = try SHA1.hash(password)
+                    let passwordDoubleHash = try SHA1.hash(passwordHash)
+                    var hash = try SHA1.hash(salt + passwordDoubleHash)
+                    for i in 0..<20 {
+                      hash[i] = hash[i] ^ passwordHash[i]
+                    }
+                    authResponse = hash
+                default: throw MySQLError(identifier: "authPlugin", reason: "Unsupported auth plugin: \(authPlugin)", source: .capture())
                 }
-                guard handshake.authPluginData.count >= 20 else {
-                    throw MySQLError(identifier: "salt", reason: "Server-supplied salt too short.", source: .capture())
-                }
-                let salt = Data(handshake.authPluginData[..<20])
-                let passwordHash = try SHA1.hash(password)
-                let passwordDoubleHash = try SHA1.hash(passwordHash)
-                var hash = try SHA1.hash(salt + passwordDoubleHash)
-                for i in 0..<20 {
-                    hash[i] = hash[i] ^ passwordHash[i]
-                }
-                authResponse = hash
-            default: throw MySQLError(identifier: "authPlugin", reason: "Unsupported auth plugin: \(authPlugin)", source: .capture())
+            } else {
+                authResponse = Data(base64Encoded: "")!
             }
             let response = MySQLHandshakeResponse41(
                 capabilities: [

--- a/Sources/MySQL/Database/MySQLDatabase.swift
+++ b/Sources/MySQL/Database/MySQLDatabase.swift
@@ -22,7 +22,8 @@ public final class MySQLDatabase: Database {
                 return client.authenticate(
                     username: config.username,
                     database: config.database,
-                    password: config.password
+                    password: config.password,
+                    characterSet: config.characterSet
                 ).transform(to: client)
             }
         }
@@ -35,4 +36,3 @@ extension DatabaseIdentifier {
         return .init("mysql")
     }
 }
-

--- a/Sources/MySQL/Database/MySQLDatabaseConfig.swift
+++ b/Sources/MySQL/Database/MySQLDatabaseConfig.swift
@@ -20,12 +20,16 @@ public struct MySQLDatabaseConfig {
     /// Database name.
     public let database: String
 
+    /// Character set. Default utf8_general_ci
+    let characterSet: MySQLCharacterSet
+
     /// Creates a new `MySQLDatabaseConfig`.
-    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String) {
+    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, characterSet: String = "utf8_general_ci") {
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
+        self.characterSet = MySQLCharacterSet(string: characterSet)
     }
 }

--- a/Sources/MySQL/Database/MySQLDatabaseConfig.swift
+++ b/Sources/MySQL/Database/MySQLDatabaseConfig.swift
@@ -1,8 +1,8 @@
 /// Config options for a `MySQLDatabase`
 public struct MySQLDatabaseConfig {
     /// Creates a `MySQLDatabaseConfig` with default settings.
-    public static func root(database: String) -> MySQLDatabaseConfig {
-        return .init(hostname: "127.0.0.1", port: 3306, username: "root", database: database)
+    public static func root(database: String) throws -> MySQLDatabaseConfig {
+        return try .init(hostname: "127.0.0.1", port: 3306, username: "root", database: database)
     }
 
     /// Destination hostname.
@@ -24,12 +24,16 @@ public struct MySQLDatabaseConfig {
     let characterSet: MySQLCharacterSet
 
     /// Creates a new `MySQLDatabaseConfig`.
-    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, characterSet: String = "utf8_general_ci") {
+    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, characterSet: String = "utf8_general_ci") throws {
+        guard let charSet = MySQLCharacterSet(string: characterSet) else {
+            throw MySQLError(identifier: "invalidCharacterSet", reason: "Cannot initialize \(MySQLCharacterSet.self) with value \(characterSet).", source: .capture())
+        }
+
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
-        self.characterSet = MySQLCharacterSet(string: characterSet)
+        self.characterSet = charSet
     }
 }

--- a/Sources/MySQL/Database/MySQLDatabaseConfig.swift
+++ b/Sources/MySQL/Database/MySQLDatabaseConfig.swift
@@ -1,8 +1,8 @@
 /// Config options for a `MySQLDatabase`
 public struct MySQLDatabaseConfig {
     /// Creates a `MySQLDatabaseConfig` with default settings.
-    public static func root(database: String) throws -> MySQLDatabaseConfig {
-        return try .init(hostname: "127.0.0.1", port: 3306, username: "root", database: database)
+    public static func root(database: String) -> MySQLDatabaseConfig {
+        return .init(hostname: "127.0.0.1", port: 3306, username: "root", database: database)
     }
 
     /// Destination hostname.
@@ -24,16 +24,12 @@ public struct MySQLDatabaseConfig {
     let characterSet: MySQLCharacterSet
 
     /// Creates a new `MySQLDatabaseConfig`.
-    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, characterSet: String = "utf8_general_ci") throws {
-        guard let charSet = MySQLCharacterSet(string: characterSet) else {
-            throw MySQLError(identifier: "invalidCharacterSet", reason: "Cannot initialize \(MySQLCharacterSet.self) with value \(characterSet).", source: .capture())
-        }
-
+    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, characterSet: MySQLCharacterSet = .utf8_general_ci) {
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
-        self.characterSet = charSet
+        self.characterSet = characterSet
     }
 }

--- a/Sources/MySQL/Database/MySQLProvider.swift
+++ b/Sources/MySQL/Database/MySQLProvider.swift
@@ -29,7 +29,7 @@ public final class MySQLProvider: Provider {
 extension MySQLDatabaseConfig: ServiceType {
     /// See `ServiceType.makeService(for:)`
     public static func makeService(for worker: Container) throws -> MySQLDatabaseConfig {
-        return .root(database: "vapor")
+        return try .root(database: "vapor")
     }
 }
 extension MySQLDatabase: ServiceType {
@@ -38,4 +38,3 @@ extension MySQLDatabase: ServiceType {
         return try .init(config: worker.make())
     }
 }
-

--- a/Sources/MySQL/Database/MySQLProvider.swift
+++ b/Sources/MySQL/Database/MySQLProvider.swift
@@ -29,7 +29,7 @@ public final class MySQLProvider: Provider {
 extension MySQLDatabaseConfig: ServiceType {
     /// See `ServiceType.makeService(for:)`
     public static func makeService(for worker: Container) throws -> MySQLDatabaseConfig {
-        return try .root(database: "vapor")
+        return .root(database: "vapor")
     }
 }
 extension MySQLDatabase: ServiceType {

--- a/Sources/MySQL/Protocol/MySQLCharacterSet.swift
+++ b/Sources/MySQL/Protocol/MySQLCharacterSet.swift
@@ -10,17 +10,31 @@ public struct MySQLCharacterSet: Equatable {
     /// charset_nr (2) -- number of the character set and collation
     var raw: UInt16
 
-    /// Creates a new `MySQLCharacterSet`
+    /// Creates a new `MySQLCharacterSet` from UInt16
+    ///
+    /// - Parameter raw: UInt16 value of collation.
     init(raw: UInt16) {
         self.raw = raw
     }
 
-    /// Creates a new `MySQLCharacterSet`
+    /// Creates a new `MySQLCharacterSet` with Byte value.
+    ///
+    /// - Parameter byte: Byte value of collation.
     init(byte: Byte) {
         self.raw = numericCast(byte)
     }
 
-    /// Creates a new `MySQLCharacterSet`
+    /// Creates a new `MySQLCharacterSet` from a string. Can return nil if the string is a invalid or unsupported collation.
+    ///
+    /// - Parameter string: Collation name of desirable character set.
+    ///
+    /// Currently accepting the followings collations:
+    /// * latin1_swedish_ci
+    /// * utf8_general_ci
+    /// * binary
+    /// * utf8mb4_unicode_ci
+    ///
+    /// Example: MySQLCharacterSet(string: "utf8mb4_unicode_ci")
     public init?(string: String) {
         switch string {
         case "latin1_swedish_ci": self.raw = 0x0008
@@ -31,13 +45,34 @@ public struct MySQLCharacterSet: Equatable {
         }
     }
 
+    /// `MySQLCharacterSet` value.
+    /// * Collation: latin1_swedish_ci
+    /// * Character set: latin1
+    /// * Id: 8
+    /// * Value: 0x0008
     public static var latin1_swedish_ci: MySQLCharacterSet = 0x0008
+    /// `MySQLCharacterSet` value.
+    /// * Collation: utf8_general_ci
+    /// * Character set: utf8
+    /// * Id: 33
+    /// * Value: 0x0021
     public static var utf8_general_ci: MySQLCharacterSet = 0x0021
+    /// `MySQLCharacterSet` value.
+    /// * Collation: binary
+    /// * Character set: binary
+    /// * Id: 63
+    /// * Value: 0x003f
     public static var binary: MySQLCharacterSet = 0x003f
+    /// `MySQLCharacterSet` value.
+    /// * Collation: utf8mb4_unicode_ci
+    /// * Character set: utf8mb4
+    /// * Id: 224
+    /// * Value: 0x00e0
     public static var utf8mb4_unicode_ci: MySQLCharacterSet = 0x00e0
 }
 
 extension MySQLCharacterSet: CustomStringConvertible {
+    /// See `CustomStringConvertible`.
     public var description: String {
         switch self {
         case .latin1_swedish_ci: return "latin1_swedish_ci"

--- a/Sources/MySQL/Protocol/MySQLCharacterSet.swift
+++ b/Sources/MySQL/Protocol/MySQLCharacterSet.swift
@@ -21,15 +21,17 @@ public struct MySQLCharacterSet: Equatable {
     }
 
     /// Creates a new `MySQLCharacterSet`
-    init(string: String) {
+    init?(string: String) {
         if string == "latin1_swedish_ci" {
             self.raw = 0x0008
+        } else if string == "utf8_general_ci" {
+              self.raw = 0x0021
         } else if string == "binary" {
             self.raw = 0x003f
         } else if string == "utf8mb4_unicode_ci" {
             self.raw = 0x00e0
-        } else { // "utf8_general_ci"
-            self.raw = 0x0021
+        } else {
+          return nil
         }
     }
 

--- a/Sources/MySQL/Protocol/MySQLCharacterSet.swift
+++ b/Sources/MySQL/Protocol/MySQLCharacterSet.swift
@@ -21,17 +21,13 @@ public struct MySQLCharacterSet: Equatable {
     }
 
     /// Creates a new `MySQLCharacterSet`
-    init?(string: String) {
-        if string == "latin1_swedish_ci" {
-            self.raw = 0x0008
-        } else if string == "utf8_general_ci" {
-              self.raw = 0x0021
-        } else if string == "binary" {
-            self.raw = 0x003f
-        } else if string == "utf8mb4_unicode_ci" {
-            self.raw = 0x00e0
-        } else {
-          return nil
+    public init?(string: String) {
+        switch string {
+        case "latin1_swedish_ci": self.raw = 0x0008
+        case "utf8_general_ci": self.raw = 0x0021
+        case "binary": self.raw = 0x003f
+        case "utf8mb4_unicode_ci": self.raw = 0x00e0
+        default: return nil
         }
     }
 

--- a/Sources/MySQL/Protocol/MySQLCharacterSet.swift
+++ b/Sources/MySQL/Protocol/MySQLCharacterSet.swift
@@ -3,9 +3,10 @@ import Bits
 /// 14.1.4 Character Set
 ///
 /// MySQL has a very flexible character set support as documented in Character Sets, Collations, Unicode.
+/// https://dev.mysql.com/doc/internals/en/x-protocol-xplugin-implementation-of-the-x-protocol.html
 ///
 /// A character set is defined in the protocol as a integer.
-struct MySQLCharacterSet: Equatable {
+public struct MySQLCharacterSet: Equatable {
     /// charset_nr (2) -- number of the character set and collation
     var raw: UInt16
 
@@ -19,17 +20,32 @@ struct MySQLCharacterSet: Equatable {
         self.raw = numericCast(byte)
     }
 
-    static var latin1_swedish_ci: MySQLCharacterSet = 0x0008
-    static var utf8_general_ci: MySQLCharacterSet = 0x0021
-    static var binary: MySQLCharacterSet = 0x003f
+    /// Creates a new `MySQLCharacterSet`
+    init(string: String) {
+        if string == "latin1_swedish_ci" {
+            self.raw = 0x0008
+        } else if string == "binary" {
+            self.raw = 0x003f
+        } else if string == "utf8mb4_unicode_ci" {
+            self.raw = 0x00e0
+        } else { // "utf8_general_ci"
+            self.raw = 0x0021
+        }
+    }
+
+    public static var latin1_swedish_ci: MySQLCharacterSet = 0x0008
+    public static var utf8_general_ci: MySQLCharacterSet = 0x0021
+    public static var binary: MySQLCharacterSet = 0x003f
+    public static var utf8mb4_unicode_ci: MySQLCharacterSet = 0x00e0
 }
 
 extension MySQLCharacterSet: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch self {
         case .latin1_swedish_ci: return "latin1_swedish_ci"
         case .utf8_general_ci: return "utf8_general_ci"
         case .binary: return "binary"
+        case .utf8mb4_unicode_ci: return "utf8mb4_unicode_ci"
         default: return "unknown \(self)"
         }
     }
@@ -37,7 +53,7 @@ extension MySQLCharacterSet: CustomStringConvertible {
 
 extension MySQLCharacterSet: ExpressibleByIntegerLiteral {
     /// See `ExpressibleByIntegerLiteral.init(integerLiteral:)`
-    init(integerLiteral value: UInt16) {
+    public init(integerLiteral value: UInt16) {
         self.raw = value
     }
 }

--- a/Tests/MySQLTests/MySQLPacketTests.swift
+++ b/Tests/MySQLTests/MySQLPacketTests.swift
@@ -85,6 +85,26 @@ class MySQLPacketTests: XCTestCase {
         print(buffer.debugDescription)
     }
 
+    func testHandshakeResponse41_example2() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 256)
+        let response = MySQLHandshakeResponse41(
+            capabilities: [
+                CLIENT_PROTOCOL_41,
+                CLIENT_PLUGIN_AUTH,
+                CLIENT_SECURE_CONNECTION,
+                CLIENT_CONNECT_WITH_DB
+            ],
+            maxPacketSize: 1_073_741_824,
+            characterSet: MySQLCharacterSet.utf8mb4_unicode_ci,
+            username: "john",
+            authResponse: .init(),
+            database: "test",
+            authPluginName: "mysql_native_password"
+        )
+        response.serialize(into: &buffer)
+        print(buffer.debugDescription)
+    }
+
     static let allTests = [
         ("testHandshakeV10_wireshark", testHandshakeV10_wireshark),
         ("testHandshakeV10_example1", testHandshakeV10_example1),

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -192,42 +192,6 @@ class MySQLTests: XCTestCase {
         XCTAssertNil(MySQLCharacterSet(string: characterSet))
     }
 
-    func testEmptyPassword() throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
-        let client = try MySQLConnection.connect(on: group) { error in
-            // for some reason connection refused error is happening?
-            if !"\(error)".contains("refused") {
-                XCTFail("\(error)")
-            }
-        }.wait()
-
-        _ = try client.authenticate(username: "root", database: "mysql").wait()
-        print("Logged as root without password.")
-        let dropUserResults = try client.simpleQuery("DROP USER IF EXISTS 'testEmptyPassword'@'localhost';").wait()
-        XCTAssertEqual(dropUserResults.count, 0)
-        let createUserResults = try client.simpleQuery("CREATE USER IF NOT EXISTS 'testEmptyPassword'@'localhost' IDENTIFIED BY '';").wait()
-        XCTAssertEqual(createUserResults.count, 0)
-        let grantPrevilegesResults = try client.simpleQuery("GRANT ALL PRIVILEGES ON vapor_database . * TO 'testEmptyPassword'@'localhost';").wait()
-        XCTAssertEqual(grantPrevilegesResults.count, 0)
-        let flushPrevilegesResults = try client.simpleQuery("FLUSH PRIVILEGES;").wait()
-        XCTAssertEqual(flushPrevilegesResults.count, 0)
-        //client.close()
-
-
-        let client2 = try MySQLConnection.connect(on: group) { error in
-            // for some reason connection refused error is happening?
-            if !"\(error)".contains("refused") {
-                XCTFail("\(error)")
-            }
-        }.wait()
-        try client2.authenticate(username: "testEmptyPassword", database: "vapor_database", password: "").wait()
-        print("Logged as testEmptyPassword with empty password.")
-        let selectResults = try client2.simpleQuery("SELECT * FROM foos;").wait()
-        XCTAssertEqual(selectResults.count, 3)
-        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "id")?.decode(Int.self), 1)
-        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "name")?.decode(String.self), "vapor1")
-    }
-
     static let allTests = [
         ("testSimpleQuery", testSimpleQuery),
         ("testQuery", testQuery),
@@ -238,7 +202,6 @@ class MySQLTests: XCTestCase {
         ("testTimePrecision", testTimePrecision),
         ("testSaveEmoticonsUnicode", testSaveEmoticonsUnicode),
         ("testStringCharacterSet", testStringCharacterSet),
-        ("testEmptyPassword", testEmptyPassword)
     ]
 }
 

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -179,19 +179,17 @@ class MySQLTests: XCTestCase {
         XCTAssertEqual(selectResults2.count, 1)
     }
 
-    func testInvalidCharacterSet() throws {
-        let hostname = "localhost"
-        let port = 3306
-        let username = "vapor_username"
-        let password = "vapor_password"
-        let database = "vapor_database"
-        let characterSet = "utf64_imaginary"
-
-        XCTAssertThrowsError(try MySQLDatabaseConfig(hostname: hostname, port: port, username: username, password: password, database: database, characterSet: characterSet)) { error in
-            XCTAssert(error is MySQLError)
-            XCTAssertEqual((error as! MySQLError).identifier, "invalidCharacterSet")
-            XCTAssertEqual((error as! MySQLError).reason, "Cannot initialize MySQLCharacterSet with value utf64_imaginary.")
-        }
+    func testStringCharacterSet() throws {
+        var characterSet = "latin1_swedish_ci"
+        XCTAssertNotNil(MySQLCharacterSet(string: characterSet))
+        characterSet = "utf8_general_ci"
+        XCTAssertNotNil(MySQLCharacterSet(string: characterSet))
+        characterSet = "binary"
+        XCTAssertNotNil(MySQLCharacterSet(string: characterSet))
+        characterSet = "utf8mb4_unicode_ci"
+        XCTAssertNotNil(MySQLCharacterSet(string: characterSet))
+        characterSet = "utf64_imaginary"
+        XCTAssertNil(MySQLCharacterSet(string: characterSet))
     }
 
     static let allTests = [
@@ -203,7 +201,7 @@ class MySQLTests: XCTestCase {
         ("testLargeValues", testLargeValues),
         ("testTimePrecision", testTimePrecision),
         ("testSaveEmoticonsUnicode", testSaveEmoticonsUnicode),
-        ("testInvalidCharacterSet", testInvalidCharacterSet),
+        ("testStringCharacterSet", testStringCharacterSet),
     ]
 }
 

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -179,6 +179,21 @@ class MySQLTests: XCTestCase {
         XCTAssertEqual(selectResults2.count, 1)
     }
 
+    func testInvalidCharacterSet() throws {
+        let hostname = "localhost"
+        let port = 3306
+        let username = "vapor_username"
+        let password = "vapor_password"
+        let database = "vapor_database"
+        let characterSet = "utf64_imaginary"
+
+        XCTAssertThrowsError(try MySQLDatabaseConfig(hostname: hostname, port: port, username: username, password: password, database: database, characterSet: characterSet)) { error in
+            XCTAssert(error is MySQLError)
+            XCTAssertEqual((error as! MySQLError).identifier, "invalidCharacterSet")
+            XCTAssertEqual((error as! MySQLError).reason, "Cannot initialize MySQLCharacterSet with value utf64_imaginary.")
+        }
+    }
+
     static let allTests = [
         ("testSimpleQuery", testSimpleQuery),
         ("testQuery", testQuery),
@@ -188,6 +203,7 @@ class MySQLTests: XCTestCase {
         ("testLargeValues", testLargeValues),
         ("testTimePrecision", testTimePrecision),
         ("testSaveEmoticonsUnicode", testSaveEmoticonsUnicode),
+        ("testInvalidCharacterSet", testInvalidCharacterSet),
     ]
 }
 

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -160,6 +160,25 @@ class MySQLTests: XCTestCase {
         )
     }
 
+    func testSaveEmoticonsUnicode() throws {
+        let client = try MySQLConnection.makeTestUtf8mb4()
+        let dropResults = try client.simpleQuery("DROP TABLE IF EXISTS emojis;").wait()
+        XCTAssertEqual(dropResults.count, 0)
+        let createResults = try client.simpleQuery("CREATE TABLE emojis (id INT SIGNED NOT NULL, description VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL);").wait()
+        XCTAssertEqual(createResults.count, 0)
+        let insertResults = try client.query("INSERT INTO emojis VALUES (?, ?);", [1, "🇧🇷 🔸 🎶 🆙 〽️ ❤️ 🎁 🕹 🚁 🚴‍♀️ 🌶 🌈 🐎 🤔"]).wait()
+        XCTAssertEqual(insertResults.count, 0)
+        let selectResults = try client.query("SELECT * FROM emojis WHERE description = ?;", ["🇧🇷 🔸 🎶 🆙 〽️ ❤️ 🎁 🕹 🚁 🚴‍♀️ 🌶 🌈 🐎 🤔"]).wait()
+        XCTAssertEqual(selectResults.count, 1)
+        print(selectResults)
+        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "id")?.decode(Int.self), 1)
+        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "description")?.decode(String.self), "🇧🇷 🔸 🎶 🆙 〽️ ❤️ 🎁 🕹 🚁 🚴‍♀️ 🌶 🌈 🐎 🤔")
+
+        // test double parameterized query
+        let selectResults2 = try client.query("SELECT * FROM emojis WHERE description = ?;", ["🇧🇷 🔸 🎶 🆙 〽️ ❤️ 🎁 🕹 🚁 🚴‍♀️ 🌶 🌈 🐎 🤔"]).wait()
+        XCTAssertEqual(selectResults2.count, 1)
+    }
+
     static let allTests = [
         ("testSimpleQuery", testSimpleQuery),
         ("testQuery", testQuery),
@@ -168,6 +187,7 @@ class MySQLTests: XCTestCase {
         ("testPipelining", testPipelining),
         ("testLargeValues", testLargeValues),
         ("testTimePrecision", testTimePrecision),
+        ("testSaveEmoticonsUnicode", testSaveEmoticonsUnicode),
     ]
 }
 
@@ -182,6 +202,19 @@ extension MySQLConnection {
             }
         }.wait()
         _ = try client.authenticate(username: "vapor_username", database: "vapor_database", password: "vapor_password").wait()
+        return client
+    }
+
+    /// Creates a test event loop and psql client.
+    static func makeTestUtf8mb4() throws -> MySQLConnection {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let client = try MySQLConnection.connect(on: group) { error in
+            // for some reason connection refused error is happening?
+            if !"\(error)".contains("refused") {
+                XCTFail("\(error)")
+            }
+        }.wait()
+        _ = try client.authenticate(username: "vapor_username", database: "vapor_database", password: "vapor_password", characterSet: .utf8mb4_unicode_ci).wait()
         return client
     }
 }

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -192,6 +192,42 @@ class MySQLTests: XCTestCase {
         XCTAssertNil(MySQLCharacterSet(string: characterSet))
     }
 
+    func testEmptyPassword() throws {
+        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let client = try MySQLConnection.connect(on: group) { error in
+            // for some reason connection refused error is happening?
+            if !"\(error)".contains("refused") {
+                XCTFail("\(error)")
+            }
+        }.wait()
+
+        _ = try client.authenticate(username: "root", database: "mysql").wait()
+        print("Logged as root without password.")
+        let dropUserResults = try client.simpleQuery("DROP USER IF EXISTS 'testEmptyPassword'@'localhost';").wait()
+        XCTAssertEqual(dropUserResults.count, 0)
+        let createUserResults = try client.simpleQuery("CREATE USER IF NOT EXISTS 'testEmptyPassword'@'localhost' IDENTIFIED BY '';").wait()
+        XCTAssertEqual(createUserResults.count, 0)
+        let grantPrevilegesResults = try client.simpleQuery("GRANT ALL PRIVILEGES ON vapor_database . * TO 'testEmptyPassword'@'localhost';").wait()
+        XCTAssertEqual(grantPrevilegesResults.count, 0)
+        let flushPrevilegesResults = try client.simpleQuery("FLUSH PRIVILEGES;").wait()
+        XCTAssertEqual(flushPrevilegesResults.count, 0)
+        //client.close()
+
+
+        let client2 = try MySQLConnection.connect(on: group) { error in
+            // for some reason connection refused error is happening?
+            if !"\(error)".contains("refused") {
+                XCTFail("\(error)")
+            }
+        }.wait()
+        try client2.authenticate(username: "testEmptyPassword", database: "vapor_database", password: "").wait()
+        print("Logged as testEmptyPassword with empty password.")
+        let selectResults = try client2.simpleQuery("SELECT * FROM foos;").wait()
+        XCTAssertEqual(selectResults.count, 3)
+        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "id")?.decode(Int.self), 1)
+        try XCTAssertEqual(selectResults[0].firstValue(forColumn: "name")?.decode(String.self), "vapor1")
+    }
+
     static let allTests = [
         ("testSimpleQuery", testSimpleQuery),
         ("testQuery", testQuery),
@@ -202,6 +238,7 @@ class MySQLTests: XCTestCase {
         ("testTimePrecision", testTimePrecision),
         ("testSaveEmoticonsUnicode", testSaveEmoticonsUnicode),
         ("testStringCharacterSet", testStringCharacterSet),
+        ("testEmptyPassword", testEmptyPassword)
     ]
 }
 


### PR DESCRIPTION
MySQL’s utf8 charset only partially implements proper UTF-8 encoding. It can only store UTF-8-encoded symbols that consist of one to three bytes; encoded symbols that take up four bytes aren’t supported.

Luckily, MySQL 5.5.3 (released in early 2010) https://dev.mysql.com/doc/relnotes/mysql/5.5/en/news-5-5-3.html introduced a new encoding called utf8mb4 which maps to proper UTF-8 and thus fully supports Unicode.

10.9.1 The utf8mb4 Character Set (4-Byte UTF-8 Unicode Encoding) https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html