### PR TITLE
Make `CLIENT_MULTI_STATEMENTS` configurable

### DIFF
--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -48,7 +48,8 @@ extension MySQLConnection {
                     CLIENT_PLUGIN_AUTH,
                     CLIENT_SECURE_CONNECTION,
                     CLIENT_CONNECT_WITH_DB,
-                    CLIENT_DEPRECATE_EOF
+                    CLIENT_DEPRECATE_EOF,
+                    CLIENT_MULTI_STATEMENTS,
                 ],
                 maxPacketSize: 1_024,
                 characterSet: 0x21,

--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -9,7 +9,7 @@ extension MySQLConnection {
     ///     - database: The database to select.
     ///     - password: Password for the user specified by `username`.
     /// - returns: A future that will complete when the authenticate is finished.
-    public func authenticate(username: String, database: String, password: String? = nil) -> Future<Void> {
+    public func authenticate(username: String, database: String, password: String? = nil, allowMultipleStatements: Bool = false) -> Future<Void> {
         var handshake: MySQLHandshakeV10?
         return send([]) { message in
             switch message {
@@ -42,15 +42,18 @@ extension MySQLConnection {
                 authResponse = hash
             default: throw MySQLError(identifier: "authPlugin", reason: "Unsupported auth plugin: \(authPlugin)", source: .capture())
             }
+            
+            var capabilities: MySQLCapabilities = [
+                CLIENT_PROTOCOL_41,
+                CLIENT_PLUGIN_AUTH,
+                CLIENT_SECURE_CONNECTION,
+                CLIENT_CONNECT_WITH_DB,
+                CLIENT_DEPRECATE_EOF,
+            ]
+            capabilities.set(CLIENT_MULTI_STATEMENTS, to: allowMultipleStatements)
+            
             let response = MySQLHandshakeResponse41(
-                capabilities: [
-                    CLIENT_PROTOCOL_41,
-                    CLIENT_PLUGIN_AUTH,
-                    CLIENT_SECURE_CONNECTION,
-                    CLIENT_CONNECT_WITH_DB,
-                    CLIENT_DEPRECATE_EOF,
-                    CLIENT_MULTI_STATEMENTS,
-                ],
+                capabilities: capabilities,
                 maxPacketSize: 1_024,
                 characterSet: 0x21,
                 username: username,

--- a/Sources/MySQL/Database/MySQLDatabase.swift
+++ b/Sources/MySQL/Database/MySQLDatabase.swift
@@ -22,7 +22,8 @@ public final class MySQLDatabase: Database {
                 return client.authenticate(
                     username: config.username,
                     database: config.database,
-                    password: config.password
+                    password: config.password,
+                    allowMultipleStatements: config.allowMultipleStatements
                 ).transform(to: client)
             }
         }

--- a/Sources/MySQL/Database/MySQLDatabaseConfig.swift
+++ b/Sources/MySQL/Database/MySQLDatabaseConfig.swift
@@ -19,13 +19,16 @@ public struct MySQLDatabaseConfig {
 
     /// Database name.
     public let database: String
+    
+    public let allowMultipleStatements: Bool
 
     /// Creates a new `MySQLDatabaseConfig`.
-    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String) {
+    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, allowMultipleStatements: Bool = false) {
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
+        self.allowMultipleStatements = allowMultipleStatements
     }
 }


### PR DESCRIPTION
I have dumped queries and trying to restore tables via `Migration`.

```swift
static func prepare(on connection: MySQLConnection) -> EventLoopFuture<Void> {
    let queries = """
        SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";  
        SET AUTOCOMMIT = 0;
        START TRANSACTION;
        SET time_zone = "+00:00";
        ...
        """
    return connection.simpleQuery(queries).transform(to: ())
}
```

Then I found multiple statements in one query is not allowed.
The problem could be solved by simply adding [this line](https://github.com/t-ae/mysql/blob/962108b9f7075d23337ea20581e36f05ed6f3d4a/Sources/MySQL/Connection/MySQLConnection%2BAuthenticate.swift#L52). And I counldn't find any way to change this configuration from outside.


This PR is just adding `CLIENT_MULTI_STATEMENTS` into capabilities.
Feel free to close if there's better way.