### PR TITLE
Changes around `MySQLCapabilities`

### DIFF
--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -9,7 +9,7 @@ extension MySQLConnection {
     ///     - database: The database to select.
     ///     - password: Password for the user specified by `username`.
     /// - returns: A future that will complete when the authenticate is finished.
-    public func authenticate(username: String, database: String, password: String? = nil) -> Future<Void> {
+    public func authenticate(username: String, database: String, password: String? = nil, capabilities: MySQLCapabilities = .default) -> Future<Void> {
         var handshake: MySQLHandshakeV10?
         return send([]) { message in
             switch message {
@@ -46,13 +46,7 @@ extension MySQLConnection {
             default: throw MySQLError(identifier: "authPlugin", reason: "Unsupported auth plugin: \(authPlugin ?? "<none>")", source: .capture())
             }
             let response = MySQLHandshakeResponse41(
-                capabilities: [
-                    .CLIENT_PROTOCOL_41,
-                    .CLIENT_PLUGIN_AUTH,
-                    .CLIENT_SECURE_CONNECTION,
-                    .CLIENT_CONNECT_WITH_DB,
-                    .CLIENT_DEPRECATE_EOF
-                ],
+                capabilities: capabilities,
                 maxPacketSize: 1_024,
                 characterSet: 0x21,
                 username: username,

--- a/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Authenticate.swift
@@ -26,7 +26,7 @@ extension MySQLConnection {
             let authResponse: Data
             switch authPlugin {
             case .some("mysql_native_password"), .none:
-                guard handshake.capabilities.get(CLIENT_SECURE_CONNECTION) else {
+                guard handshake.capabilities.contains(.CLIENT_SECURE_CONNECTION) else {
                     throw MySQLError(identifier: "authproto", reason: "Pre-4.1 auth protocol is not supported or safe.", source: .capture())
                 }
                 guard let password = password else {
@@ -47,11 +47,11 @@ extension MySQLConnection {
             }
             let response = MySQLHandshakeResponse41(
                 capabilities: [
-                    CLIENT_PROTOCOL_41,
-                    CLIENT_PLUGIN_AUTH,
-                    CLIENT_SECURE_CONNECTION,
-                    CLIENT_CONNECT_WITH_DB,
-                    CLIENT_DEPRECATE_EOF
+                    .CLIENT_PROTOCOL_41,
+                    .CLIENT_PLUGIN_AUTH,
+                    .CLIENT_SECURE_CONNECTION,
+                    .CLIENT_CONNECT_WITH_DB,
+                    .CLIENT_DEPRECATE_EOF
                 ],
                 maxPacketSize: 1_024,
                 characterSet: 0x21,

--- a/Sources/MySQL/Database/MySQLDatabase.swift
+++ b/Sources/MySQL/Database/MySQLDatabase.swift
@@ -22,7 +22,8 @@ public final class MySQLDatabase: Database {
                 return client.authenticate(
                     username: config.username,
                     database: config.database,
-                    password: config.password
+                    password: config.password,
+                    capabilities: config.capabilities
                 ).transform(to: client)
             }
         }

--- a/Sources/MySQL/Database/MySQLDatabaseConfig.swift
+++ b/Sources/MySQL/Database/MySQLDatabaseConfig.swift
@@ -19,13 +19,17 @@ public struct MySQLDatabaseConfig {
 
     /// Database name.
     public let database: String
+    
+    // Capability flags
+    public let capabilities: MySQLCapabilities
 
     /// Creates a new `MySQLDatabaseConfig`.
-    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String) {
+    public init(hostname: String = "127.0.0.1", port: Int = 3306, username: String, password: String? = nil, database: String, capabilities: MySQLCapabilities = .default) {
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
+        self.capabilities = capabilities
     }
 }

--- a/Sources/MySQL/Pipeline/MySQLPacketDecoder.swift
+++ b/Sources/MySQL/Pipeline/MySQLPacketDecoder.swift
@@ -71,7 +71,7 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
             let ok = try MySQLOKPacket(bytes: &buffer, capabilities: capabilities, length: numericCast(length))
             packet = .ok(ok)
         } else if next == 0xFE && length < 9 {
-            if capabilities.get(CLIENT_DEPRECATE_EOF) {
+            if capabilities.contains(.CLIENT_DEPRECATE_EOF) {
                 // parse EOF packet
                 let eof = try MySQLOKPacket(bytes: &buffer, capabilities: capabilities, length: numericCast(length))
                 packet = .ok(eof)
@@ -103,7 +103,7 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
         textState: MySQLTextProtocolState,
         capabilities: MySQLCapabilities
     ) throws -> DecodingState {
-        if !capabilities.get(CLIENT_DEPRECATE_EOF) {
+        if !capabilities.contains(.CLIENT_DEPRECATE_EOF) {
             // check for error or OK packet
             let peek = buffer.peekInteger(as: Byte.self, skipping: 4)
             switch peek {
@@ -215,7 +215,7 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
                 session.connectionState = .statement(.columnsDone)
             }
 
-            if !capabilities.get(CLIENT_DEPRECATE_EOF) {
+            if !capabilities.contains(.CLIENT_DEPRECATE_EOF) {
                 return try decodeBasicPacket(ctx: ctx, buffer: &buffer, capabilities: capabilities, forwarding: false)
             }
         case .columns(var remaining):
@@ -234,7 +234,7 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
                 session.connectionState = .statement(.columns(remaining: remaining))
             }
         case .columnsDone:
-            if !capabilities.get(CLIENT_DEPRECATE_EOF) {
+            if !capabilities.contains(.CLIENT_DEPRECATE_EOF) {
                 return try decodeBasicPacket(ctx: ctx, buffer: &buffer, capabilities: capabilities, forwarding: false)
             }
         case .waitingExecute:
@@ -268,7 +268,7 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
                 session.connectionState = .statement(.rowColumns(columns: columns, remaining: remaining))
             }
         case .rowColumnsDone(let columns):
-            if !capabilities.get(CLIENT_DEPRECATE_EOF) {
+            if !capabilities.contains(.CLIENT_DEPRECATE_EOF) {
                 let result = try decodeBasicPacket(ctx: ctx, buffer: &buffer, capabilities: capabilities, forwarding: false)
                 session.connectionState = .statement(.rows(columns: columns))
                 return result

--- a/Sources/MySQL/Protocol/MySQLCapabilities.swift
+++ b/Sources/MySQL/Protocol/MySQLCapabilities.swift
@@ -137,7 +137,20 @@ public struct MySQLCapabilities: OptionSet {
     /// Therefore, the EOF packet in the Text Resultset is replaced with an OK packet. EOF packets are deprecated as of MySQL 5.7.5.
     public static let CLIENT_DEPRECATE_EOF = MySQLCapabilities(rawValue: 0x01000000)
     
-    
+    /// Default capabilities.
+    ///
+    /// - CLIENT_PROTOCOL_41,
+    /// - CLIENT_PLUGIN_AUTH,
+    /// - CLIENT_SECURE_CONNECTION,
+    /// - CLIENT_CONNECT_WITH_DB,
+    /// - CLIENT_DEPRECATE_EOF
+    public static let `default`: MySQLCapabilities = [
+        .CLIENT_PROTOCOL_41,
+        .CLIENT_PLUGIN_AUTH,
+        .CLIENT_SECURE_CONNECTION,
+        .CLIENT_CONNECT_WITH_DB,
+        .CLIENT_DEPRECATE_EOF
+    ]
 }
 
 extension MySQLCapabilities: CustomStringConvertible {

--- a/Sources/MySQL/Protocol/MySQLCapabilities.swift
+++ b/Sources/MySQL/Protocol/MySQLCapabilities.swift
@@ -1,11 +1,15 @@
 /// The capability flags are used by the client and server to indicate which features they support and want to use.
 ///
 /// https://dev.mysql.com/doc/internals/en/capability-flags.html#packet-Protocol::CapabilityFlags
-struct MySQLCapabilities {
-    /// The raw capability value.
-    var raw: UInt32
-
-    /// Create a new `MySQLCapabilityFlags` from the upper and lower values.
+public struct MySQLCapabilities: OptionSet {
+    
+    public var rawValue: UInt32
+    
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+    
+    /// Create a new `MySQLCapabilities` from the upper and lower values.
     init(upper: UInt16? = nil, lower: UInt16) {
         var raw: UInt32 = 0
         if let upper = upper {
@@ -14,199 +18,164 @@ struct MySQLCapabilities {
         } else {
             raw = numericCast(lower)
         }
-        self.raw = raw
+        self.init(rawValue: raw)
     }
-
-    /// Returns true if the capability is enabled.
-    func get(_ capability: MySQLCapability) -> Bool {
-        return raw & capability > 0
-    }
-
-    /// Enables or disables a capability.
-    mutating func set(_ capability: MySQLCapability, to enabled: Bool) {
-        if enabled {
-            raw |= capability
-        } else {
-            raw &= ~capability
-        }
-    }
-}
-
-extension MySQLCapabilities: ExpressibleByDictionaryLiteral {
-    /// See `ExpressibleByDictionaryLiteral.init(dictionaryLiteral)`
-    init(dictionaryLiteral elements: (MySQLCapability, Bool)...) {
-        var capabilities = MySQLCapabilities(lower: 0)
-        for (capability, enabled) in elements {
-            capabilities.set(capability, to: enabled)
-        }
-        self = capabilities
-    }
-}
-
-extension MySQLCapabilities: ExpressibleByArrayLiteral {
-    /// See `ExpressibleByDictionaryLiteral.init(arrayLiteral)`
-    init(arrayLiteral elements: MySQLCapability...) {
-        var capabilities = MySQLCapabilities(lower: 0)
-        for capability in elements {
-            capabilities.set(capability, to: true)
-        }
-        self = capabilities
-    }
+    
+    /// Use the improved version of Old Password Authentication.
+    /// note: Assumed to be set since 4.1.1.
+    public static let CLIENT_LONG_PASSWORD = MySQLCapabilities(rawValue: 0x00000001)
+    
+    /// Send found rows instead of affected rows in EOF_Packet.
+    public static let CLIENT_FOUND_ROWS = MySQLCapabilities(rawValue: 0x00000002)
+    
+    /// Longer flags in Protocol::ColumnDefinition320.
+    /// Server: Supports longer flags.
+    /// Client: Expects longer flags.
+    public static let CLIENT_LONG_FLAG = MySQLCapabilities(rawValue: 0x00000004)
+    
+    /// Database (schema) name can be specified on connect in Handshake Response Packet.
+    /// Server: Supports schema-name in Handshake Response Packet.
+    /// Client: Handshake Response Packet contains a schema-name.
+    public static let CLIENT_CONNECT_WITH_DB = MySQLCapabilities(rawValue: 0x00000008)
+    
+    /// Server: Do not permit database.table.column.
+    public static let CLIENT_NO_SCHEMA = MySQLCapabilities(rawValue: 0x00000010)
+    
+    /// Compression protocol supported.
+    /// Server: Supports compression.
+    /// Client: Switches to Compression compressed protocol after successful authentication.
+    public static let CLIENT_COMPRESS = MySQLCapabilities(rawValue: 0x00000020)
+    
+    /// Special handling of ODBC behavior.
+    /// note: No special behavior since 3.22.
+    public static let CLIENT_ODBC = MySQLCapabilities(rawValue: 0x00000040)
+    
+    /// Can use LOAD DATA LOCAL.
+    /// Server: Enables the LOCAL INFILE request of LOAD DATA|XML.
+    /// Client: Will handle LOCAL INFILE request.
+    public static let CLIENT_LOCAL_FILES = MySQLCapabilities(rawValue: 0x00000080)
+    
+    /// Server: Parser can ignore spaces before '('.
+    /// Client: Let the parser ignore spaces before '('.
+    public static let CLIENT_IGNORE_SPACE = MySQLCapabilities(rawValue: 0x00000100)
+    
+    /// Server: Supports the 4.1 protocol.
+    /// Client: Uses the 4.1 protocol.
+    /// note: this value was CLIENT_CHANGE_USER in 3.22, unused in 4.0
+    public static let CLIENT_PROTOCOL_41 = MySQLCapabilities(rawValue: 0x00000200)
+    
+    /// wait_timeout versus wait_interactive_timeout.
+    /// Server: Supports interactive and noninteractive clients.
+    /// Client: Client is interactive.
+    /// See mysql_real_connect()
+    public static let CLIENT_INTERACTIVE = MySQLCapabilities(rawValue: 0x00000400)
+    
+    /// Server: Supports SSL.
+    /// Client: Switch to SSL after sending the capability-flags.
+    public static let CLIENT_SSL = MySQLCapabilities(rawValue: 0x00000800)
+    
+    /// Client: Do not issue SIGPIPE if network failures occur (libmysqlclient only).
+    /// See mysql_real_connect()
+    public static let CLIENT_IGNORE_SIGPIPE = MySQLCapabilities(rawValue: 0x00001000)
+    
+    /// Server: Can send status flags in EOF_Packet.
+    /// Client: Expects status flags in EOF_Packet.
+    /// note: This flag is optional in 3.23, but always set by the server since 4.0.
+    public static let CLIENT_TRANSACTIONS = MySQLCapabilities(rawValue: 0x00002000)
+    
+    /// Unused.
+    /// note: Was named CLIENT_PROTOCOL_41 in 4.1.0.
+    public static let CLIENT_RESERVED = MySQLCapabilities(rawValue: 0x00004000)
+    
+    /// Server: Supports Authentication::Native41.
+    /// Client: Supports Authentication::Native41.
+    public static let CLIENT_SECURE_CONNECTION = MySQLCapabilities(rawValue: 0x00008000)
+    
+    /// Server: Can handle multiple statements per COM_QUERY and COM_STMT_PREPARE.
+    /// Client: May send multiple statements per COM_QUERY and COM_STMT_PREPARE.
+    /// note: Was named CLIENT_MULTI_QUERIES in 4.1.0, renamed later.
+    /// requires: CLIENT_PROTOCOL_41
+    public static let CLIENT_MULTI_STATEMENTS = MySQLCapabilities(rawValue: 0x00010000)
+    
+    /// Server: Can send multiple resultsets for COM_QUERY.
+    /// Client: Can handle multiple resultsets for COM_QUERY.
+    /// requires: CLIENT_PROTOCOL_41
+    public static let CLIENT_MULTI_RESULTS = MySQLCapabilities(rawValue: 0x00020000)
+    
+    /// Server: Can send multiple resultsets for COM_STMT_EXECUTE.
+    /// Client: Can handle multiple resultsets for COM_STMT_EXECUTE.
+    /// requires: CLIENT_PROTOCOL_41
+    public static let CLIENT_PS_MULTI_RESULTS = MySQLCapabilities(rawValue: 0x00040000)
+    
+    /// Server: Sends extra data in Initial Handshake Packet and supports the pluggable authentication protocol.
+    /// Client: Supports authentication plugins.
+    /// Requires: CLIENT_PROTOCOL_41
+    public static let CLIENT_PLUGIN_AUTH = MySQLCapabilities(rawValue: 0x00080000)
+    
+    /// Server: Permits connection attributes in Protocol::HandshakeResponse41.
+    /// Client: Sends connection attributes in Protocol::HandshakeResponse41.
+    public static let CLIENT_CONNECT_ATTRS = MySQLCapabilities(rawValue: 0x00100000)
+    
+    /// Server: Understands length-encoded integer for auth response data in Protocol::HandshakeResponse41.
+    /// Client: Length of auth response data in Protocol::HandshakeResponse41 is a length-encoded integer.
+    /// note: The flag was introduced in 5.6.6, but had the wrong value.
+    public static let CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = MySQLCapabilities(rawValue: 0x00200000)
+    
+    /// Server: Announces support for expired password extension.
+    /// Client: Can handle expired passwords.
+    /// https://dev.mysql.com/doc/internals/en/cs-sect-expired-password.html
+    public static let CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS = MySQLCapabilities(rawValue: 0x00400000)
+    
+    /// Server: Can set SERVER_SESSION_STATE_CHANGED in the Status Flags and send session-state change data after a OK packet.
+    /// Client: Expects the server to send sesson-state changes after a OK packet.
+    public static let CLIENT_SESSION_TRACK = MySQLCapabilities(rawValue: 0x00800000)
+    
+    /// Server: Can send OK after a Text Resultset.
+    /// Client: Expects an OK (instead of EOF) after the resultset rows of a Text Resultset.
+    /// To support CLIENT_SESSION_TRACK, additional information must be sent after all successful commands.
+    /// Although the OK packet is extensible, the EOF packet is not due to the overlap of its bytes with the content of the Text Resultset Row.
+    /// Therefore, the EOF packet in the Text Resultset is replaced with an OK packet. EOF packets are deprecated as of MySQL 5.7.5.
+    public static let CLIENT_DEPRECATE_EOF = MySQLCapabilities(rawValue: 0x01000000)
+    
+    
 }
 
 extension MySQLCapabilities: CustomStringConvertible {
-    var description: String {
-        let all: [String: MySQLCapability] = [
-            "CLIENT_LONG_PASSWORD": CLIENT_LONG_PASSWORD,
-            "CLIENT_FOUND_ROWS": CLIENT_FOUND_ROWS,
-            "CLIENT_LONG_FLAG": CLIENT_LONG_FLAG,
-            "CLIENT_CONNECT_WITH_DB": CLIENT_CONNECT_WITH_DB,
-            "CLIENT_NO_SCHEMA": CLIENT_NO_SCHEMA,
-            "CLIENT_COMPRESS": CLIENT_COMPRESS,
-            "CLIENT_ODBC": CLIENT_ODBC,
-            "CLIENT_LOCAL_FILES": CLIENT_LOCAL_FILES,
-            "CLIENT_IGNORE_SPACE": CLIENT_IGNORE_SPACE,
-            "CLIENT_PROTOCOL_41": CLIENT_PROTOCOL_41,
-            "CLIENT_INTERACTIVE": CLIENT_INTERACTIVE,
-            "CLIENT_SSL": CLIENT_SSL,
-            "CLIENT_IGNORE_SIGPIPE": CLIENT_IGNORE_SIGPIPE,
-            "CLIENT_TRANSACTIONS": CLIENT_TRANSACTIONS,
-            "CLIENT_RESERVED": CLIENT_RESERVED,
-            "CLIENT_SECURE_CONNECTION": CLIENT_SECURE_CONNECTION,
-            "CLIENT_MULTI_STATEMENTS": CLIENT_MULTI_STATEMENTS,
-            "CLIENT_MULTI_RESULTS": CLIENT_MULTI_RESULTS,
-            "CLIENT_PS_MULTI_RESULTS": CLIENT_PS_MULTI_RESULTS,
-            "CLIENT_PLUGIN_AUTH": CLIENT_PLUGIN_AUTH,
-            "CLIENT_CONNECT_ATTRS": CLIENT_CONNECT_ATTRS,
-            "CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA": CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA,
-            "CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS": CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS,
-            "CLIENT_SESSION_TRACK": CLIENT_SESSION_TRACK,
-            "CLIENT_DEPRECATE_EOF": CLIENT_DEPRECATE_EOF,
+    public static let all: [String: MySQLCapabilities] = [
+        "CLIENT_LONG_PASSWORD": CLIENT_LONG_PASSWORD,
+        "CLIENT_FOUND_ROWS": CLIENT_FOUND_ROWS,
+        "CLIENT_LONG_FLAG": CLIENT_LONG_FLAG,
+        "CLIENT_CONNECT_WITH_DB": CLIENT_CONNECT_WITH_DB,
+        "CLIENT_NO_SCHEMA": CLIENT_NO_SCHEMA,
+        "CLIENT_COMPRESS": CLIENT_COMPRESS,
+        "CLIENT_ODBC": CLIENT_ODBC,
+        "CLIENT_LOCAL_FILES": CLIENT_LOCAL_FILES,
+        "CLIENT_IGNORE_SPACE": CLIENT_IGNORE_SPACE,
+        "CLIENT_PROTOCOL_41": CLIENT_PROTOCOL_41,
+        "CLIENT_INTERACTIVE": CLIENT_INTERACTIVE,
+        "CLIENT_SSL": CLIENT_SSL,
+        "CLIENT_IGNORE_SIGPIPE": CLIENT_IGNORE_SIGPIPE,
+        "CLIENT_TRANSACTIONS": CLIENT_TRANSACTIONS,
+        "CLIENT_RESERVED": CLIENT_RESERVED,
+        "CLIENT_SECURE_CONNECTION": CLIENT_SECURE_CONNECTION,
+        "CLIENT_MULTI_STATEMENTS": CLIENT_MULTI_STATEMENTS,
+        "CLIENT_MULTI_RESULTS": CLIENT_MULTI_RESULTS,
+        "CLIENT_PS_MULTI_RESULTS": CLIENT_PS_MULTI_RESULTS,
+        "CLIENT_PLUGIN_AUTH": CLIENT_PLUGIN_AUTH,
+        "CLIENT_CONNECT_ATTRS": CLIENT_CONNECT_ATTRS,
+        "CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA": CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA,
+        "CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS": CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS,
+        "CLIENT_SESSION_TRACK": CLIENT_SESSION_TRACK,
+        "CLIENT_DEPRECATE_EOF": CLIENT_DEPRECATE_EOF,
         ]
+    
+    public var description: String {
         var desc: [String] = []
-        for (name, flag) in all {
-            if get(flag) {
+        for (name, flag) in MySQLCapabilities.all {
+            if contains(flag) {
                 desc.append(name)
             }
         }
         return desc.joined(separator: " | ")
     }
 }
-
-typealias MySQLCapability = UInt32
-
-/// Use the improved version of Old Password Authentication.
-/// note: Assumed to be set since 4.1.1.
-var CLIENT_LONG_PASSWORD: MySQLCapability = 0x00000001
-
-/// Send found rows instead of affected rows in EOF_Packet.
-var CLIENT_FOUND_ROWS: MySQLCapability = 0x00000002
-
-/// Longer flags in Protocol::ColumnDefinition320.
-/// Server: Supports longer flags.
-/// Client: Expects longer flags.
-var CLIENT_LONG_FLAG: MySQLCapability = 0x00000004
-
-/// Database (schema) name can be specified on connect in Handshake Response Packet.
-/// Server: Supports schema-name in Handshake Response Packet.
-/// Client: Handshake Response Packet contains a schema-name.
-var CLIENT_CONNECT_WITH_DB: MySQLCapability = 0x00000008
-
-/// Server: Do not permit database.table.column.
-var CLIENT_NO_SCHEMA: MySQLCapability = 0x00000010
-
-/// Compression protocol supported.
-/// Server: Supports compression.
-/// Client: Switches to Compression compressed protocol after successful authentication.
-var CLIENT_COMPRESS: MySQLCapability = 0x00000020
-
-/// Special handling of ODBC behavior.
-/// note: No special behavior since 3.22.
-var CLIENT_ODBC: MySQLCapability = 0x00000040
-
-/// Can use LOAD DATA LOCAL.
-/// Server: Enables the LOCAL INFILE request of LOAD DATA|XML.
-/// Client: Will handle LOCAL INFILE request.
-var CLIENT_LOCAL_FILES: MySQLCapability = 0x00000080
-
-/// Server: Parser can ignore spaces before '('.
-/// Client: Let the parser ignore spaces before '('.
-var CLIENT_IGNORE_SPACE: MySQLCapability = 0x00000100
-
-/// Server: Supports the 4.1 protocol.
-/// Client: Uses the 4.1 protocol.
-/// note: this value was CLIENT_CHANGE_USER in 3.22, unused in 4.0
-var CLIENT_PROTOCOL_41: MySQLCapability = 0x00000200
-
-/// wait_timeout versus wait_interactive_timeout.
-/// Server: Supports interactive and noninteractive clients.
-/// Client: Client is interactive.
-/// See mysql_real_connect()
-var CLIENT_INTERACTIVE: MySQLCapability = 0x00000400
-
-/// Server: Supports SSL.
-/// Client: Switch to SSL after sending the capability-flags.
-var CLIENT_SSL: MySQLCapability = 0x00000800
-
-/// Client: Do not issue SIGPIPE if network failures occur (libmysqlclient only).
-/// See mysql_real_connect()
-var CLIENT_IGNORE_SIGPIPE: MySQLCapability = 0x00001000
-
-/// Server: Can send status flags in EOF_Packet.
-/// Client: Expects status flags in EOF_Packet.
-/// note: This flag is optional in 3.23, but always set by the server since 4.0.
-var CLIENT_TRANSACTIONS: MySQLCapability = 0x00002000
-
-/// Unused.
-/// note: Was named CLIENT_PROTOCOL_41 in 4.1.0.
-var CLIENT_RESERVED: MySQLCapability = 0x00004000
-
-/// Server: Supports Authentication::Native41.
-/// Client: Supports Authentication::Native41.
-var CLIENT_SECURE_CONNECTION: MySQLCapability = 0x00008000
-
-/// Server: Can handle multiple statements per COM_QUERY and COM_STMT_PREPARE.
-/// Client: May send multiple statements per COM_QUERY and COM_STMT_PREPARE.
-/// note: Was named CLIENT_MULTI_QUERIES in 4.1.0, renamed later.
-/// requires: CLIENT_PROTOCOL_41
-var CLIENT_MULTI_STATEMENTS: MySQLCapability = 0x00010000
-
-/// Server: Can send multiple resultsets for COM_QUERY.
-/// Client: Can handle multiple resultsets for COM_QUERY.
-/// requires: CLIENT_PROTOCOL_41
-var CLIENT_MULTI_RESULTS: MySQLCapability = 0x00020000
-
-/// Server: Can send multiple resultsets for COM_STMT_EXECUTE.
-/// Client: Can handle multiple resultsets for COM_STMT_EXECUTE.
-/// requires: CLIENT_PROTOCOL_41
-var CLIENT_PS_MULTI_RESULTS: MySQLCapability = 0x00040000
-
-/// Server: Sends extra data in Initial Handshake Packet and supports the pluggable authentication protocol.
-/// Client: Supports authentication plugins.
-/// Requires: CLIENT_PROTOCOL_41
-var CLIENT_PLUGIN_AUTH: MySQLCapability = 0x00080000
-
-/// Server: Permits connection attributes in Protocol::HandshakeResponse41.
-/// Client: Sends connection attributes in Protocol::HandshakeResponse41.
-var CLIENT_CONNECT_ATTRS: MySQLCapability = 0x00100000
-
-/// Server: Understands length-encoded integer for auth response data in Protocol::HandshakeResponse41.
-/// Client: Length of auth response data in Protocol::HandshakeResponse41 is a length-encoded integer.
-/// note: The flag was introduced in 5.6.6, but had the wrong value.
-var CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA: MySQLCapability = 0x00200000
-
-/// Server: Announces support for expired password extension.
-/// Client: Can handle expired passwords.
-/// https://dev.mysql.com/doc/internals/en/cs-sect-expired-password.html
-var CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS: MySQLCapability = 0x00400000
-
-/// Server: Can set SERVER_SESSION_STATE_CHANGED in the Status Flags and send session-state change data after a OK packet.
-/// Client: Expects the server to send sesson-state changes after a OK packet.
-var CLIENT_SESSION_TRACK: MySQLCapability = 0x00800000
-
-/// Server: Can send OK after a Text Resultset.
-/// Client: Expects an OK (instead of EOF) after the resultset rows of a Text Resultset.
-/// To support CLIENT_SESSION_TRACK, additional information must be sent after all successful commands.
-/// Although the OK packet is extensible, the EOF packet is not due to the overlap of its bytes with the content of the Text Resultset Row.
-/// Therefore, the EOF packet in the Text Resultset is replaced with an OK packet. EOF packets are deprecated as of MySQL 5.7.5.
-var CLIENT_DEPRECATE_EOF: MySQLCapability = 0x01000000

--- a/Sources/MySQL/Protocol/MySQLEOFPacket.swift
+++ b/Sources/MySQL/Protocol/MySQLEOFPacket.swift
@@ -21,7 +21,7 @@ struct MySQLEOFPacket {
         default: throw MySQLError(identifier: "eofPacketHeader", reason: "Invalid EOF packet header: \(header)", source: .capture())
         }
 
-        if capabilities.get(CLIENT_PROTOCOL_41) {
+        if capabilities.contains(.CLIENT_PROTOCOL_41) {
             warningsCount = try bytes.requireInteger(endianness: .little, source: .capture())
             statusFlags = try .init(raw: bytes.requireInteger(endianness: .little, source: .capture()))
         } else {

--- a/Sources/MySQL/Protocol/MySQLErrorPacket.swift
+++ b/Sources/MySQL/Protocol/MySQLErrorPacket.swift
@@ -30,7 +30,7 @@ struct MySQLErrorPacket {
         }
 
         errorCode = try bytes.requireInteger(endianness: .little, source: .capture())
-        if capabilities.get(CLIENT_PROTOCOL_41) {
+        if capabilities.contains(.CLIENT_PROTOCOL_41) {
             sqlStateMarker = try bytes.requireString(length: 1, source: .capture())
             sqlState = try bytes.requireString(length: 5, source: .capture())
         }

--- a/Sources/MySQL/Protocol/MySQLHandshakeResponse41.swift
+++ b/Sources/MySQL/Protocol/MySQLHandshakeResponse41.swift
@@ -54,14 +54,14 @@ struct MySQLHandshakeResponse41 {
 
     /// Serializes the `MySQLHandshakeResponse41` into a buffer.
     func serialize(into buffer: inout ByteBuffer) {
-        buffer.write(integer: capabilities.raw, endianness: .little)
+        buffer.write(integer: capabilities.rawValue, endianness: .little)
         buffer.write(integer: maxPacketSize, endianness: .little)
         buffer.write(integer: Byte(characterSet.raw & 0xFF), endianness: .little)
         /// string[23]     reserved (all [0])
         buffer.write(bytes: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
         buffer.write(nullTerminated: username)
-        assert(capabilities.get(CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) == false, "CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA not supported")
-        if capabilities.get(CLIENT_SECURE_CONNECTION) {
+        assert(capabilities.contains(.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) == false, "CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA not supported")
+        if capabilities.contains(.CLIENT_SECURE_CONNECTION) {
             assert(authResponse.count < Byte.max, "auth response too large")
             buffer.write(integer: Byte(authResponse.count), endianness: .little)
             buffer.write(bytes: authResponse)
@@ -70,16 +70,16 @@ struct MySQLHandshakeResponse41 {
             buffer.write(bytes: authResponse)
             buffer.write(integer: Byte(0))
         }
-        if capabilities.get(CLIENT_CONNECT_WITH_DB) {
+        if capabilities.contains(.CLIENT_CONNECT_WITH_DB) {
             buffer.write(nullTerminated: database)
         } else {
             assert(database == "", "CLIENT_CONNECT_WITH_DB not enabled")
         }
-        if capabilities.get(CLIENT_PLUGIN_AUTH) {
+        if capabilities.contains(.CLIENT_PLUGIN_AUTH) {
             buffer.write(nullTerminated: authPluginName)
         } else {
             assert(authPluginName == "", "CLIENT_PLUGIN_AUTH not enabled")
         }
-        assert(capabilities.get(CLIENT_CONNECT_ATTRS) == false, "CLIENT_CONNECT_ATTRS not supported")
+        assert(capabilities.contains(.CLIENT_CONNECT_ATTRS) == false, "CLIENT_CONNECT_ATTRS not supported")
     }
 }

--- a/Sources/MySQL/Protocol/MySQLHandshakeV10.swift
+++ b/Sources/MySQL/Protocol/MySQLHandshakeV10.swift
@@ -60,7 +60,7 @@ struct MySQLHandshakeV10 {
             )
 
             let authPluginDataLength: Byte
-            if capabilities.get(CLIENT_PLUGIN_AUTH) {
+            if capabilities.contains(.CLIENT_PLUGIN_AUTH) {
                 authPluginDataLength = try bytes.requireInteger(endianness: .little, source: .capture())
             } else {
                 authPluginDataLength = try bytes.requireInteger(endianness: .little, source: .capture())
@@ -71,8 +71,8 @@ struct MySQLHandshakeV10 {
             let reserved = try bytes.requireBytes(length: 10, source: .capture())
             assert(reserved == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-            if capabilities.get(CLIENT_SECURE_CONNECTION) {
-                if capabilities.get(CLIENT_PLUGIN_AUTH) {
+            if capabilities.contains(.CLIENT_SECURE_CONNECTION) {
+                if capabilities.contains(.CLIENT_PLUGIN_AUTH) {
                     let len = max(13, authPluginDataLength - 8)
                     let authPluginDataPart2 = try bytes.requireBytes(length: numericCast(len), source: .capture())
                     self.authPluginData = Data(authPluginDataPart1 + authPluginDataPart2)
@@ -86,7 +86,7 @@ struct MySQLHandshakeV10 {
                 self.authPluginData = Data(authPluginDataPart1)
             }
 
-            if capabilities.get(CLIENT_PLUGIN_AUTH) {
+            if capabilities.contains(.CLIENT_PLUGIN_AUTH) {
                 self.authPluginName = try bytes.requireNullTerminatedString(source: .capture())
             }
         } else {

--- a/Sources/MySQL/Protocol/MySQLOKPacket.swift
+++ b/Sources/MySQL/Protocol/MySQLOKPacket.swift
@@ -38,16 +38,16 @@ struct MySQLOKPacket {
         affectedRows = try bytes.requireLengthEncodedInteger(source: .capture())
         lastInsertID = try bytes.requireLengthEncodedInteger(source: .capture())
         
-        if capabilities.get(CLIENT_PROTOCOL_41) {
+        if capabilities.contains(.CLIENT_PROTOCOL_41) {
             statusFlags = try .init(raw: bytes.requireInteger(endianness: .little, source: .capture()))
             warningsCount = try bytes.requireInteger(endianness: .little, source: .capture())
-        } else if capabilities.get(CLIENT_TRANSACTIONS) {
+        } else if capabilities.contains(.CLIENT_TRANSACTIONS) {
             statusFlags = try .init(raw: bytes.requireInteger(endianness: .little, source: .capture()))
         } else {
-            statusFlags = .init(raw: 0)
+            statusFlags = []
         }
 
-        if capabilities.get(CLIENT_SESSION_TRACK) {
+        if capabilities.contains(.CLIENT_SESSION_TRACK) {
             if bytes.readerIndex - startIndex >= length {
                 // entire packet has been read already
                 info = ""

--- a/Tests/MySQLTests/MySQLPacketTests.swift
+++ b/Tests/MySQLTests/MySQLPacketTests.swift
@@ -12,9 +12,9 @@ class MySQLPacketTests: XCTestCase {
         XCTAssertEqual(handshakeV10.serverVersion, "5.7.18")
         XCTAssertEqual(handshakeV10.connectionID, 5)
         XCTAssertEqual(handshakeV10.authPluginData.count, 21)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PLUGIN_AUTH), true)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_SECURE_CONNECTION), true)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PROTOCOL_41), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PLUGIN_AUTH), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_SECURE_CONNECTION), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PROTOCOL_41), true)
         XCTAssertEqual(handshakeV10.characterSet, 33)
         XCTAssertEqual(handshakeV10.statusFlags, 2)
         XCTAssertEqual(handshakeV10.authPluginName, "mysql_native_password")
@@ -28,9 +28,9 @@ class MySQLPacketTests: XCTestCase {
         XCTAssertEqual(handshakeV10.serverVersion, "5.5.2-m2")
         XCTAssertEqual(handshakeV10.connectionID, 11)
         XCTAssertEqual(handshakeV10.authPluginData.count, 20)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PLUGIN_AUTH), false)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_SECURE_CONNECTION), true)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PROTOCOL_41), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PLUGIN_AUTH), false)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_SECURE_CONNECTION), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PROTOCOL_41), true)
         XCTAssertEqual(handshakeV10.characterSet, 8)
         XCTAssertEqual(handshakeV10.statusFlags, 2)
         XCTAssertEqual(handshakeV10.authPluginName, nil)
@@ -44,9 +44,9 @@ class MySQLPacketTests: XCTestCase {
         XCTAssertEqual(handshakeV10.serverVersion, "5.6.4-m7-log")
         XCTAssertEqual(handshakeV10.connectionID, 2646)
         XCTAssertEqual(handshakeV10.authPluginData.count, 21)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PLUGIN_AUTH), true)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_SECURE_CONNECTION), true)
-        XCTAssertEqual(handshakeV10.capabilities.get(CLIENT_PROTOCOL_41), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PLUGIN_AUTH), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_SECURE_CONNECTION), true)
+        XCTAssertEqual(handshakeV10.capabilities.contains(.CLIENT_PROTOCOL_41), true)
         XCTAssertEqual(handshakeV10.characterSet, 8)
         XCTAssertEqual(handshakeV10.statusFlags, 2)
         XCTAssertEqual(handshakeV10.authPluginName, "mysql_native_password")
@@ -55,7 +55,7 @@ class MySQLPacketTests: XCTestCase {
     func testHandshakeResponse41_wireshark() throws {
         _ = ByteBufferAllocator().buffer(capacity: 256)
         _ = MySQLHandshakeResponse41(
-            capabilities: [CLIENT_PROTOCOL_41],
+            capabilities: [.CLIENT_PROTOCOL_41],
             maxPacketSize: 1_073_741_824,
             characterSet: 0x0a,
             username: "root",
@@ -69,10 +69,10 @@ class MySQLPacketTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 256)
         let response = MySQLHandshakeResponse41(
             capabilities: [
-                CLIENT_PROTOCOL_41,
-                CLIENT_PLUGIN_AUTH,
-                CLIENT_SECURE_CONNECTION,
-                CLIENT_CONNECT_WITH_DB
+                .CLIENT_PROTOCOL_41,
+                .CLIENT_PLUGIN_AUTH,
+                .CLIENT_SECURE_CONNECTION,
+                .CLIENT_CONNECT_WITH_DB
             ],
             maxPacketSize: 1_073_741_824,
             characterSet: 0x0a,


### PR DESCRIPTION
Took over from #163.

This PR contains 3 changes.
1. Change `MySQLCapabilities` and `MySQLCapability` into `MySQLCapabilities: OptionSet`
2. Make `MySQLCapabilities` public
3. Add `capabilities` in `MySQLDatabaseConfig`

All capability flags are turned into static member of `MySQLCapabilities`. 
There is also `MySQLCapabilities.default` which is took from [here](https://github.com/vapor/mysql/blob/cda473257572c8e02706d0c65fd145765c5a414d/Sources/MySQL/Connection/MySQLConnection%2BAuthenticate.swift#L50-L54).

Threre was [DIctionary literal initializer](https://github.com/vapor/mysql/blob/cda473257572c8e02706d0c65fd145765c5a414d/Sources/MySQL/Protocol/MySQLCapabilities.swift#L35-L44) but I didn't take over this because it looks unnecessary.