### PR TITLE
Extended MySQLCapabilities with MariaDB specific capabilities

### DIFF
--- a/Sources/MySQL/Protocol/MySQLHandshakeResponse41.swift
+++ b/Sources/MySQL/Protocol/MySQLHandshakeResponse41.swift
@@ -54,7 +54,7 @@ struct MySQLHandshakeResponse41 {
 
     /// Serializes the `MySQLHandshakeResponse41` into a buffer.
     func serialize(into buffer: inout ByteBuffer) {
-        buffer.write(integer: capabilities.raw, endianness: .little)
+        buffer.write(integer: capabilities.mysqlSpecific, endianness: .little, as: UInt32.self)
         buffer.write(integer: maxPacketSize, endianness: .little)
         buffer.write(integer: Byte(characterSet.raw & 0xFF), endianness: .little)
         /// string[23]     reserved (all [0])

--- a/Sources/MySQL/Protocol/MySQLHandshakeV10.swift
+++ b/Sources/MySQL/Protocol/MySQLHandshakeV10.swift
@@ -67,9 +67,20 @@ struct MySQLHandshakeV10 {
                 assert(authPluginDataLength == 0x00, "invalid auth plugin data filler: \(authPluginDataLength)")
             }
 
-            /// string[10]     reserved (all [00])
-            let reserved = try bytes.requireBytes(length: 10, source: .capture())
-            assert(reserved == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            /// string[6]     reserved (all [00])
+            let reserved = try bytes.requireBytes(length: 6, source: .capture())
+            assert(reserved == [0, 0, 0, 0, 0, 0])
+
+            if capabilities.get(CLIENT_LONG_PASSWORD) {
+                /// string[4]     reserved (all [00])
+                let reserved2 = try bytes.requireBytes(length: 4, source: .capture())
+                assert(reserved2 == [0, 0, 0, 0])
+            } else {
+                /// Capabilities 3rd part. MariaDB specific flags.
+                /// See: [MariaDB Initial Handshake Packet specific flags](https://mariadb.com/kb/en/library/1-connecting-connecting/)
+                let mariaDBSpecific: UInt32 = try bytes.requireInteger(endianness: .little, source: .capture())
+                self.capabilities.mariaDBSpecific = mariaDBSpecific
+            }
 
             if capabilities.get(CLIENT_SECURE_CONNECTION) {
                 if capabilities.get(CLIENT_PLUGIN_AUTH) {


### PR DESCRIPTION
Circumvented an assert in MySQLHandshakeV10.swift that failed with MariaDB 10.2 or later because of specific flags.
See: [MariaDB Initial Handshake Packet specific flags](https://mariadb.com/kb/en/library/1-connecting-connecting/)