### PR TITLE
fix deprecated EOF support for MySQL 5.5 and 5.6

### DIFF
--- a/Sources/MySQL/Connection/MySQLConnection+Query.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Query.swift
@@ -12,7 +12,7 @@ extension MySQLConnection {
         var rows: [[MySQLColumn: MySQLData]] = []
         return self.query(query) { row in
             rows.append(row)
-        }.map(to: [[MySQLColumn: MySQLData]].self) {
+        }.map {
             return rows
         }
     }
@@ -66,7 +66,7 @@ extension MySQLConnection {
             )
             let comClose = MySQLPacket.ComStmtClose(statementID: ok.statementID)
             var columns: [MySQLColumnDefinition41] = []
-            return self.send([.comStmtExecute(comExecute), .comStmtClose(comClose)]) { message in
+            return self.send([.comStmtExecute(comExecute)]) { message in
                 switch message {
                 case .columnDefinition41(let col):
                     columns.append(col)

--- a/Sources/MySQL/Connection/MySQLConnection+Query.swift
+++ b/Sources/MySQL/Connection/MySQLConnection+Query.swift
@@ -66,7 +66,7 @@ extension MySQLConnection {
             )
             let comClose = MySQLPacket.ComStmtClose(statementID: ok.statementID)
             var columns: [MySQLColumnDefinition41] = []
-            return self.send([.comStmtExecute(comExecute)]) { message in
+            return self.send([.comStmtExecute(comExecute), .comStmtClose(comClose)]) { message in
                 switch message {
                 case .columnDefinition41(let col):
                     columns.append(col)

--- a/Sources/MySQL/Connection/MySQLConnectionHandler.swift
+++ b/Sources/MySQL/Connection/MySQLConnectionHandler.swift
@@ -34,7 +34,7 @@ final class MySQLConnectionHandler: ChannelInboundHandler {
     // MARK: Private
     
     private func handlePacket(ctx: ChannelHandlerContext, packet: MySQLPacket) throws {
-        print("✅ \(packet) \(state)")
+        // print("✅ \(packet) \(state)")
         switch state {
         case .nascent:
             switch packet {

--- a/Sources/MySQL/Pipeline/MySQLPacketDecoder.swift
+++ b/Sources/MySQL/Pipeline/MySQLPacketDecoder.swift
@@ -198,7 +198,6 @@ final class MySQLPacketDecoder: ByteToMessageDecoder {
 
     /// Statement Protocol (Prepared Query)
     func decodeStatementProtocol(ctx: ChannelHandlerContext, buffer: inout ByteBuffer, statementState: MySQLStatementProtocolState, capabilities: MySQLCapabilities) throws -> DecodingState {
-        print(statementState)
         switch statementState {
         case .waitingPrepare:
             // check for error packet

--- a/Sources/MySQL/Pipeline/MySQLPacketEncoder.swift
+++ b/Sources/MySQL/Pipeline/MySQLPacketEncoder.swift
@@ -21,7 +21,7 @@ final class MySQLPacketEncoder: MessageToByteEncoder {
     ///     - data: The data to encode into a `ByteBuffer`.
     ///     - out: The `ByteBuffer` into which we want to encode.
     func encode(ctx: ChannelHandlerContext, data message: MySQLPacket, out: inout ByteBuffer) throws {
-        print("➡️ \(message)")
+        // print("➡️ \(message)")
         // print("\(#function) \(session.handshakeState)")
         let writeOffset = out.writerIndex
         out.write(bytes: [0x00, 0x00, 0x00, 0x00]) // save room for length

--- a/Sources/MySQL/Pipeline/MySQLPacketEncoder.swift
+++ b/Sources/MySQL/Pipeline/MySQLPacketEncoder.swift
@@ -21,7 +21,7 @@ final class MySQLPacketEncoder: MessageToByteEncoder {
     ///     - data: The data to encode into a `ByteBuffer`.
     ///     - out: The `ByteBuffer` into which we want to encode.
     func encode(ctx: ChannelHandlerContext, data message: MySQLPacket, out: inout ByteBuffer) throws {
-        // print("➡️ \(message)")
+        print("➡️ \(message)")
         // print("\(#function) \(session.handshakeState)")
         let writeOffset = out.writerIndex
         out.write(bytes: [0x00, 0x00, 0x00, 0x00]) // save room for length

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -19,6 +19,7 @@ class MySQLTests: XCTestCase {
             "hello".convertToMySQLData(),
             "world".convertToMySQLData()
         ])).wait()
+        print(results)
         try XCTAssertEqual(results[0].firstValue(forColumn: "test")?.decode(String.self), "helloworld")
         print(results)
     }

--- a/circle.yml
+++ b/circle.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - run:
           name: Clone Fluent MySQL
-          command: git clone -b gm https://github.com/vapor/fluent-mysql.git
+          command: git clone -b master https://github.com/vapor/fluent-mysql.git
           working_directory: ~/
       - run:
           name: Switch Fluent MySQL to this MySQL revision

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,6 @@
 version: 2
 
 jobs:
-
-
-  macos:
-    macos:
-      xcode: "9.2"
-    steps:
-      - run: brew install mysql
-      - run: brew services start mysql
-      - run: sleep 3 && mysqladmin -uroot create test
-      - checkout
-      - run: swift build
-      - run: echo "CREATE DATABASE vapor_test" | mysql -uroot
-      # - run: swift build -c release
-      - run: swift test
-
   5.5-linux:
     docker:
       - image: codevapor/swift:4.1
@@ -34,7 +19,24 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
-
+  5.6-linux:
+    docker:
+      - image: codevapor/swift:4.1
+      - image: mysql:5.6
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: vapor_database
+          # MYSQL_ROOT_HOST: %
+          MYSQL_USER: vapor_username
+          MYSQL_PASSWORD: vapor_password
+    steps:
+      - checkout
+      - run: 
+          name: Compile code
+          command: swift build
+      - run: 
+          name: Run unit tests
+          command: swift test
   5.7-linux:
     docker:
       - image: codevapor/swift:4.1
@@ -53,7 +55,6 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
-
   8.0-linux:
     docker:
       - image: codevapor/swift:4.1
@@ -72,7 +73,6 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test -Xswiftc -DSSL_TESTS
-
   mariadb-10.3-linux:
     docker:
       - image: codevapor/swift:4.1
@@ -91,7 +91,6 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
-
   8.0-linux-fluent:
     docker:
       - image: codevapor/swift:4.1
@@ -114,7 +113,6 @@ jobs:
           name: Run Fluent MySQL unit tests
           command: swift test
           working_directory: ~/fluent-mysql
-
   linux-release:
     docker:
       - image: codevapor/swift:4.1
@@ -123,20 +121,17 @@ jobs:
       - run: 
           name: Compile code with optimizations
           command: swift build -c release
-
-
 workflows:
   version: 2
   tests:
     jobs:
-     # - macos
-     # - 5.5-linux
+      - 5.5-linux
+      - 5.6-linux
       - 5.7-linux
       - 8.0-linux
       - 8.0-linux-fluent
       - mariadb-10.3-linux
       - linux-release
-
   nightly:
     triggers:
       - schedule:
@@ -144,8 +139,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
-                
+                - master 
     jobs:
       - 8.0-linux
-      # - macos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,21 @@ services:
       MYSQL_PASSWORD: vapor_password
     ports:
       - 3306:3306
+  mysql-56:
+    image: mysql:5.6
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: vapor_database
+      MYSQL_USER: vapor_username
+      MYSQL_PASSWORD: vapor_password
+    ports:
+      - 3306:3306
+  mysql-55:
+    image: mysql:5.5
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: vapor_database
+      MYSQL_USER: vapor_username
+      MYSQL_PASSWORD: vapor_password
+    ports:
+      - 3306:3306


### PR DESCRIPTION
Moving from `QueueHandler` to a specialized `MySQLConnectionHandler` created some issues with the old `CLIENT_DEPRECATED_EOF` support. This update fixes the `MySQLPacketEncoder` to parse deprecated EOF packets _before_ firing inbound packet events to avoid state being overwritten.