### PR TITLE
store Decimal using Codable impl

### DIFF
--- a/Sources/MySQL/Connection/MySQLData.swift
+++ b/Sources/MySQL/Connection/MySQLData.swift
@@ -26,15 +26,6 @@ public struct MySQLData: Equatable, Encodable {
         self.storage = .binary(binary)
     }
 
-    public init(decimal: Decimal) {
-        let binary = MySQLBinaryData(
-            type: .MYSQL_TYPE_NEWDECIMAL,
-            isUnsigned: true,
-            storage: .string(.init(decimal.description.utf8))
-        )
-        self.storage = .binary(binary)
-    }
-
     /// Creates a new `MySQLData` from `Data`.
     public init(data: Data?) {
         let binary = MySQLBinaryData(
@@ -398,24 +389,6 @@ extension String: MySQLDataConvertible {
             throw MySQLError(identifier: "string", reason: "Cannot decode String from MySQLData: \(mysqlData).")
         }
         return string
-    }
-}
-
-extension Decimal: MySQLDataConvertible {
-    /// See `MySQLDataConvertible.convertToMySQLData(format:)`
-    public func convertToMySQLData() -> MySQLData {
-        return MySQLData(decimal: self)
-    }
-
-    /// See `MySQLDataConvertible.convertFromMySQLData()`
-    public static func convertFromMySQLData(_ mysqlData: MySQLData) throws -> Decimal {
-        guard let string = mysqlData.string() else {
-            throw MySQLError(identifier: "decimal", reason: "Cannot decode String from MySQLData: \(mysqlData).")
-        }
-        guard let decimal = Decimal(string: string) else {
-            throw MySQLError(identifier: "decimal", reason: "Cannot decode Decimal from String: \(string).")
-        }
-        return decimal
     }
 }
 

--- a/Sources/MySQL/Data/MySQLData+Decimal.swift
+++ b/Sources/MySQL/Data/MySQLData+Decimal.swift
@@ -1,0 +1,23 @@
+extension Decimal: MySQLDataTypeStaticRepresentable {
+    /// See `MySQLDataTypeStaticRepresentable`.
+    public static var mysqlDataType: MySQLDataType {
+        /// https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/Decimal.swift#L567
+        /// decimal has max string size of 200
+        return .varchar(200)
+    }
+}
+
+extension Decimal: MySQLDataConvertible {
+    /// See `MySQLDataConvertible`.
+    public func convertToMySQLData() -> MySQLData {
+        return .init(string: self.description)
+    }
+    
+    /// See `MySQLDataConvertible`.
+    public static func convertFromMySQLData(_ mysqlData: MySQLData) throws -> Decimal {
+        guard let decimal = try Decimal(string: String.convertFromMySQLData(mysqlData)) else {
+            throw MySQLError(identifier: "decimal", reason: "Could not decode decimal from MySQLData: \(mysqlData).")
+        }
+        return decimal
+    }
+}

--- a/Sources/MySQL/SQL/MySQLDataType.swift
+++ b/Sources/MySQL/SQL/MySQLDataType.swift
@@ -9,7 +9,7 @@ public struct MySQLDataType: SQLDataType, Equatable {
     /// See `SQLDataType`.
     public static func dataType(appropriateFor type: Any.Type) -> MySQLDataType? {
         guard let type = type as? MySQLDataTypeStaticRepresentable.Type else {
-            return nil
+            return .json
         }
         return type.mysqlDataType
     }

--- a/Sources/MySQL/SQL/MySQLDataTypeStaticRepresentable.swift
+++ b/Sources/MySQL/SQL/MySQLDataTypeStaticRepresentable.swift
@@ -25,13 +25,6 @@ extension String: MySQLDataTypeStaticRepresentable {
     }
 }
 
-extension Decimal: MySQLDataTypeStaticRepresentable {
-    /// See `MySQLDataTypeStaticRepresentable`.
-    public static var mysqlDataType: MySQLDataType {
-        return .decimal
-    }
-}
-
 extension FixedWidthInteger {
     /// See `MySQLDataTypeStaticRepresentable`.
     public static var mysqlDataType: MySQLDataType {


### PR DESCRIPTION
This PR proposes changing the storage method of `Decimal` implemented by #171. The problem with the previous implementation is that `Foundation.Decimal` can represent much larger values than MySQL's `DECIMAL` is able to store. Foundation's `Decimal` type includes a `Codable` implementation that losslessly stores the data. This PR simply removes the custom `MySQLDataConvertible` implementation so that `Decimal` falls back on its default `Codable` encoding.

The downside to this change is that it will be harder to work with `Decimal` values directly in MySQL. The upside is that any `Decimal` value you can represent in Swift can be losslessly stored in your data layer.

This PR is up for discussion!