### PR TITLE
Fix Microsecond calculation for MySQLTime

### DIFF
--- a/Sources/MySQL/Connection/MySQLData.swift
+++ b/Sources/MySQL/Connection/MySQLData.swift
@@ -605,14 +605,7 @@ extension Date {
         let comps = Calendar(identifier: .gregorian)
             .dateComponents(in: TimeZone(secondsFromGMT: 0)!, from: self)
 
-
-        /// For some reason comps.nanosecond is `nil` on linux :(
-        let microsecond: UInt32
-        #if os(macOS)
-        microsecond = numericCast((comps.nanosecond ?? 0) / 1_000)
-        #else
-        microsecond = numericCast(UInt64(timeIntervalSince1970 * 1_000_000) % 1_000_000)
-        #endif
+        let microsecond = UInt32(abs(timeIntervalSince1970.truncatingRemainder(dividingBy: 1) * 1_000_000))
 
         return MySQLTime(
             year: numericCast(comps.year ?? 0),

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -157,6 +157,14 @@ class MySQLTests: XCTestCase {
             accuracy: 5
         )
     }
+ 
+    func testDateBefore1970() throws {
+        let time = Date(timeIntervalSince1970: 1.1).convertToMySQLTime()
+        let time2 = Date(timeIntervalSince1970: -1.1).convertToMySQLTime()
+        
+        XCTAssert(time.microsecond == UInt32(100000))
+        XCTAssert(time2.microsecond == UInt32(100000))
+    }
 
     func testSaveEmoticonsUnicode() throws {
         let client = try MySQLConnection.makeTest()


### PR DESCRIPTION
Fixed the microsecond calculation for MySQLTime and added tests for the calculations.

The old calculation delivered an error when the date was from before 1970 (epoch).