### PR TITLE
improve MySQL row decoder performance

### DIFF
--- a/Sources/MySQL/Connection/MySQLColumn.swift
+++ b/Sources/MySQL/Connection/MySQLColumn.swift
@@ -55,9 +55,20 @@ extension Dictionary where Key == MySQLColumn {
     /// Accesses the _first_ value from this dictionary with a matching field name.
     public func firstValue(forColumn columnName: String, inTable table: String? = nil) -> Value? {
         if table != nil, let specific = self[MySQLColumn(table: table, name: columnName)] {
+            // check for column with matching table name
             return specific
+        } else if let unspecific = self[MySQLColumn(table: nil, name: columnName)] {
+            // check for column without table name
+            return unspecific
+        } else if table == nil {
+            // check for column with table name where we don't specify one
+            for (col, row) in self {
+                if col.name == columnName {
+                    return row
+                }
+            }
         }
-        return self[MySQLColumn(table: nil, name: columnName)]
+        return nil
     }
 
     /// Access a `Value` from this dictionary keyed by `MySQLColumn`s

--- a/Sources/MySQL/Connection/MySQLColumn.swift
+++ b/Sources/MySQL/Connection/MySQLColumn.swift
@@ -54,12 +54,10 @@ extension MySQLColumnDefinition41 {
 extension Dictionary where Key == MySQLColumn {
     /// Accesses the _first_ value from this dictionary with a matching field name.
     public func firstValue(forColumn columnName: String, inTable table: String? = nil) -> Value? {
-        for (field, value) in self {
-            if (table == nil || field.table == nil || field.table == table) && field.name == columnName {
-                return value
-            }
+        if table != nil, let specific = self[MySQLColumn(table: table, name: columnName)] {
+            return specific
         }
-        return nil
+        return self[MySQLColumn(table: nil, name: columnName)]
     }
 
     /// Access a `Value` from this dictionary keyed by `MySQLColumn`s


### PR DESCRIPTION
Adds a couple of changes to the MySQL row decoder to improve its performance. `allKeys` is no longer computed or used. This check was redundant since `decodeNil` does the same thing. The `firstRow` code was also improved to take better advantage of existing dictionary lookup algorithms. 

Addresses #206. 