### PR TITLE
add MySQLTime description

### DIFF
--- a/Sources/MySQL/Connection/MySQLData.swift
+++ b/Sources/MySQL/Connection/MySQLData.swift
@@ -557,6 +557,12 @@ struct MySQLTime: Equatable {
     var microsecond: UInt32
 }
 
+extension MySQLTime: CustomStringConvertible {
+    var description: String {
+        return "\(self.year)-\(self.month)-\(self.day) \(self.hour):\(self.minute):\(self.second).\(self.microsecond)"
+    }
+}
+
 extension Calendar {
     func ccomponent<I>(_ component: Calendar.Component, from date: Date) -> I where I: FixedWidthInteger {
         return numericCast(self.component(component, from: date))

--- a/Tests/MySQLTests/MySQLTests.swift
+++ b/Tests/MySQLTests/MySQLTests.swift
@@ -338,6 +338,12 @@ class MySQLTests: XCTestCase {
         print(data)
     }
     
+    func testMySQLTimeDescription() throws {
+        let date = Date(timeIntervalSinceReferenceDate: 314159269)
+        let time = date.convertToMySQLTime()
+        XCTAssertEqual("\(time)", "2010-12-16 2:27:49.0")
+    }
+    
     static let allTests = [
         ("testBenchmark", testBenchmark),
         ("testSimpleQuery", testSimpleQuery),
@@ -357,6 +363,7 @@ class MySQLTests: XCTestCase {
         ("testDecimalPrecision", testDecimalPrecision),
         ("testZeroRowSelect", testZeroRowSelect),
         ("testZeroLengthArray", testZeroLengthArray),
+        ("testMySQLTimeDescription", testMySQLTimeDescription),
     ]
 }
 


### PR DESCRIPTION
Adds `CustomStringConvertible` conformance to `MySQLTime`. Fixes #218.