### PR TITLE
Widen pin on swift-crypto dependency

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
+permissions:
+  contents: read
 
 env:
   LOG_LEVEL: info
@@ -28,7 +30,7 @@ jobs:
     container: swift:noble
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { 'fetch-depth': 0 }
       - name: API breaking changes
         run: |
@@ -53,7 +55,7 @@ jobs:
           MYSQL_USER: test_username
           MYSQL_PASSWORD: test_password
           MYSQL_DATABASE: test_database
-    container: swift:6.1-noble
+    container: swift:6.2-noble
     strategy:
       fail-fast: false
       matrix:
@@ -64,10 +66,10 @@ jobs:
           - percona:8.0
     steps:
       - name: Check out package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { path: 'mysql-kit' }
       - name: Check out dependent
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: vapor/fluent-mysql-driver
           path: fluent-mysql-driver
@@ -85,15 +87,14 @@ jobs:
         dbimage:
           - mysql:5.7
           - mysql:8.0
-          - mysql:9.3
+          - mysql:9.6
           - mariadb:10.4
           - mariadb:11
           - percona:8.0
         runner:
-          # List is deliberately incomplete; we want to avoid running 50 jobs on every commit
-          - swift:5.10-jammy
-          - swift:6.0-noble
+          - swift:6.0-jammy
           - swift:6.1-noble
+          - swift:6.2-noble
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
     services:
@@ -106,7 +107,7 @@ jobs:
           MYSQL_DATABASE: test_database
     steps:
       - name: Check out package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run local tests with coverage and TSan
         run: swift test --enable-code-coverage --sanitize=thread
       - name: Submit coverage report to Codecov.io
@@ -121,9 +122,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos-version: macos-14
-            xcode-version: latest-stable
           - macos-version: macos-15
+            xcode-version: latest-stable
+          - macos-version: macos-26
             xcode-version: latest-stable
     runs-on: ${{ matrix.macos-version }}
     steps:
@@ -146,7 +147,7 @@ jobs:
               GRANT ALL PRIVILEGES ON test_database.* TO test_username@localhost;
           SQL
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run tests with code coverage
         run: swift test --enable-code-coverage
         env: { MYSQL_HOSTNAME: '127.0.0.1' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,8 @@ jobs:
           MYSQL_PASSWORD: test_password
           MYSQL_DATABASE: test_database
     steps:
+      - name: Install curl
+        run: apt-get update && apt-get install -y curl
       - name: Check out package
         uses: actions/checkout@v6
       - name: Run local tests with coverage and TSan

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.20.0"),
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.7.2"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.33.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.82.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.30.0"),
     ],


### PR DESCRIPTION
**These changes are now available in [4.10.1](https://github.com/vapor/mysql-kit/releases/tag/4.10.1)**


### What?
Widens the supported `swift-crypto` range to include the 4+ series of releases.

### Why?
1) Using `swift-crypto` 4.2.0 doesn't seem to impact the building or tests
2) Allows for newer libraries that need `swift-crypto` 4+ tags to still use this library
3) This combined with `mysql-nio` widening its pin on `swift-crypto` would allow `vapor` users depending on `fluent-mysql-driver` to use the latest, and safest, `swift-crypto` versions.

### Related to 
https://github.com/vapor/mysql-nio/pull/120 